### PR TITLE
feat: enable GitHub Pages and add live demo links

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -2,7 +2,7 @@
 
 문서와 데이터를 읽기 좋은 단일 HTML 시각화로 변환하는 Claude Code 플러그인입니다.
 
-[English](README.md)
+[English](README.md) · [Live Demo](https://seokrae.github.io/claude-visualize/examples/)
 
 ## 무엇을 하나요
 
@@ -39,7 +39,7 @@
 
 | 파일 | 타입 | 내용 |
 |------|------|------|
-| [`examples/index.html`](examples/index.html) | — | 갤러리 인덱스 — 6종 샘플 한 페이지에서 탐색 |
+| [`examples/index.html`](examples/index.html) · [↗ Live](https://seokrae.github.io/claude-visualize/examples/) | — | 갤러리 인덱스 — 6종 샘플 한 페이지에서 탐색 |
 | [`examples/report.html`](examples/report.html) | `report` | API 마이그레이션 분석 리포트 (요약, 배경, 리스크, 다음 단계) |
 | [`examples/flow.html`](examples/flow.html) | `flow` | 결제 프로세스 흐름도 (체크아웃 → 정산) |
 | [`examples/comparison.html`](examples/comparison.html) | `comparison` | 세션 쿠키 vs JWT 인증 아키텍처 비교 |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Claude Code plugin that converts documents and data into readable, self-contained HTML visualizations.
 
-[한국어](README.ko.md)
+[한국어](README.ko.md) · [Live Demo](https://seokrae.github.io/claude-visualize/examples/)
 
 ## What It Does
 
@@ -39,7 +39,7 @@ Live samples for each visualization type — open in any browser.
 
 | File | Type | Preview |
 |------|------|---------|
-| [`examples/index.html`](examples/index.html) | — | Gallery index — all 6 types in one page |
+| [`examples/index.html`](examples/index.html) · [↗ Live](https://seokrae.github.io/claude-visualize/examples/) | — | Gallery index — all 6 types in one page |
 | [`examples/report.html`](examples/report.html) | `report` | API migration analysis with summary, background, risks, and next actions |
 | [`examples/flow.html`](examples/flow.html) | `flow` | End-to-end payment process from checkout to settlement |
 | [`examples/comparison.html`](examples/comparison.html) | `comparison` | Session-cookie vs JWT auth architecture — metrics and recommendation |


### PR DESCRIPTION
## 변경 내용

- README(EN/KO) 상단에 Live Demo 링크 추가
- examples 테이블에 `↗ Live` 링크 추가

## GitHub Pages 활성화

PR 머지 후 별도로 GitHub Pages 활성화 (API 호출)

Closes #6