### PR TITLE
feat: add analysis visualization type

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -18,6 +18,7 @@
 | `timeline` | 순차 단계, 롤아웃 일정, 인시던트 진행 |
 | `dashboard` | KPI, 운영 상태, 스냅샷 요약 |
 | `deck` | 발표 슬라이드, 스토리텔링 |
+| `analysis` | 데이터 분포, 통계 패턴, 밀도 커브 |
 
 ## 설치
 
@@ -46,6 +47,7 @@
 | [`examples/timeline.html`](examples/timeline.html) | `timeline` | 스테이블코인 서비스 6단계 런치 타임라인 |
 | [`examples/dashboard.html`](examples/dashboard.html) | `dashboard` | 결제 시스템 실시간 KPI 대시보드 |
 | [`examples/deck.html`](examples/deck.html) | `deck` | Q2 엔지니어링 전략 발표 슬라이드 (6장) |
+| [`examples/analysis.html`](examples/analysis.html) | `analysis` | 인증 응답 시간 분포 분석 — 바 차트, 듀얼축, 밀도 커브, 데이터 테이블 |
 
 ## 사용 예시
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Give it any document, data set, or analysis — it produces a single `.html` fil
 | `timeline` | Sequential steps, rollout schedules, incident progression |
 | `dashboard` | KPIs, operational status, snapshot summaries |
 | `deck` | Presentation slides, storytelling |
+| `analysis` | Data distribution, statistical patterns, density curves |
 
 ## Installation
 
@@ -46,6 +47,7 @@ Live samples for each visualization type — open in any browser.
 | [`examples/timeline.html`](examples/timeline.html) | `timeline` | 6-phase stablecoin service launch rollout with status tracking |
 | [`examples/dashboard.html`](examples/dashboard.html) | `dashboard` | Real-time payment system KPIs, service health, and recent alerts |
 | [`examples/deck.html`](examples/deck.html) | `deck` | Q2 engineering strategy presentation — 6 slides |
+| [`examples/analysis.html`](examples/analysis.html) | `analysis` | Auth response time distribution — bar, dual-axis, density curves, data table |
 
 ## Usage Examples
 

--- a/examples/analysis.html
+++ b/examples/analysis.html
@@ -1,0 +1,539 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>API Response Time Distribution Analysis</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Sans+KR:wght@400;500;700&display=swap" rel="stylesheet" />
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+  <style>
+    :root {
+      color-scheme: dark;
+      --surface: rgba(12, 21, 36, 0.92);
+      --surface-2: rgba(16, 28, 46, 0.96);
+      --border: rgba(153, 186, 255, 0.14);
+      --border-strong: rgba(153, 186, 255, 0.28);
+      --text: #edf3ff;
+      --text-muted: #98abc9;
+      --accent: #68b6ff;
+      --accent-2: #70e1cb;
+      --danger: #ff8c9f;
+      --warning: #ffd072;
+      --purple: #c8a0ff;
+      --radius-xl: 28px;
+      --radius-lg: 20px;
+      --radius-md: 14px;
+      --shadow: 0 24px 72px rgba(0,0,0,0.34);
+      --font-sans: "Inter","Noto Sans KR",-apple-system,sans-serif;
+      --max: 1100px;
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; min-height: 100%; }
+    body {
+      font-family: var(--font-sans);
+      color: var(--text);
+      background:
+        radial-gradient(circle at top left, rgba(104,182,255,0.15), transparent 30%),
+        linear-gradient(180deg, #091320 0%, #07101b 50%, #050a12 100%);
+      line-height: 1.65;
+      letter-spacing: -0.014em;
+      -webkit-font-smoothing: antialiased;
+    }
+    .page { width: min(var(--max), calc(100% - 32px)); margin: 0 auto; padding: 28px 0 64px; }
+    main { display: grid; gap: 18px; }
+
+    /* Hero */
+    .hero {
+      border: 1px solid var(--border);
+      background: linear-gradient(180deg, rgba(15,27,44,0.98), rgba(8,15,28,0.94));
+      border-radius: var(--radius-xl); padding: 32px; box-shadow: var(--shadow);
+    }
+    .eyebrow {
+      display: inline-flex; align-items: center; gap: 8px;
+      padding: 8px 12px; border-radius: 999px; margin-bottom: 20px;
+      border: 1px solid rgba(104,182,255,0.2); background: rgba(104,182,255,0.08);
+      color: #c2ddff; font-size: 12px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase;
+    }
+    h1 { margin: 0 0 14px; font-size: clamp(2rem, 4vw, 3.2rem); line-height: 1.08; letter-spacing: -0.035em; font-weight: 900; }
+    .hero-meta { display: flex; flex-wrap: wrap; gap: 20px; margin-top: 20px; }
+    .meta-item { font-size: 13px; color: var(--text-muted); }
+    .meta-item strong { color: var(--text); font-weight: 600; }
+
+    /* Section */
+    .section {
+      border: 1px solid var(--border); background: var(--surface);
+      border-radius: var(--radius-xl); padding: 26px; box-shadow: var(--shadow);
+    }
+    .section-head { margin-bottom: 20px; }
+    h2 { margin: 0 0 6px; font-size: clamp(1.3rem, 2.5vw, 1.8rem); line-height: 1.1; letter-spacing: -0.03em; }
+    .section-head p { margin: 0; color: var(--text-muted); font-size: 14px; }
+    h3 { margin: 0 0 8px; font-size: 1.05rem; letter-spacing: -0.02em; font-weight: 700; }
+    p { margin: 0; color: var(--text-muted); font-size: 15px; }
+
+    /* Observation cards */
+    .obs-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; }
+    .obs-card {
+      border: 1px solid var(--border); border-radius: var(--radius-md);
+      padding: 16px; background: rgba(255,255,255,0.03);
+    }
+    .obs-label { font-size: 11px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-muted); margin-bottom: 8px; }
+    .obs-value { font-size: 1.6rem; font-weight: 800; letter-spacing: -0.04em; line-height: 1; }
+    .obs-sub { font-size: 12px; color: var(--text-muted); margin-top: 6px; }
+
+    /* Chart wrapper */
+    .chart-wrap {
+      position: relative; width: 100%;
+      background: rgba(255,255,255,0.02);
+      border: 1px solid var(--border); border-radius: var(--radius-md);
+      padding: 20px;
+    }
+    .chart-wrap canvas { display: block; }
+    .chart-note {
+      margin-top: 14px; padding: 12px 16px;
+      border-radius: 10px; background: rgba(255,255,255,0.03);
+      border-left: 3px solid var(--border-strong);
+      font-size: 13px; color: var(--text-muted); line-height: 1.65;
+    }
+    .chart-note strong { color: var(--text); }
+
+    /* Two col */
+    .two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+
+    /* Data table */
+    .data-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+    .data-table th {
+      text-align: left; padding: 10px 14px;
+      font-size: 11px; font-weight: 700; letter-spacing: 0.07em; text-transform: uppercase;
+      color: var(--text-muted); border-bottom: 1px solid var(--border);
+    }
+    .data-table td { padding: 10px 14px; border-bottom: 1px solid rgba(153,186,255,0.07); color: var(--text-muted); }
+    .data-table tr:last-child td { border-bottom: none; }
+    .data-table td.num { font-weight: 600; color: var(--text); text-align: right; font-variant-numeric: tabular-nums; }
+    .data-table td.highlight { color: var(--warning); font-weight: 700; }
+    .data-table td.ok { color: var(--accent-2); font-weight: 600; }
+
+    /* Marker legend */
+    .marker-legend { display: flex; flex-wrap: wrap; gap: 16px; margin-top: 12px; }
+    .marker-item { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--text-muted); }
+    .marker-line { width: 24px; height: 2px; border-top: 2px dashed; }
+
+    /* Synthesis cards */
+    .synth-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; }
+    .synth-card {
+      border: 1px solid var(--border); border-radius: var(--radius-lg);
+      padding: 20px; background: rgba(255,255,255,0.03);
+    }
+    .synth-label {
+      font-size: 11px; font-weight: 800; letter-spacing: 0.08em; text-transform: uppercase;
+      margin-bottom: 10px;
+    }
+    .synth-verdict { font-size: 15px; font-weight: 700; color: var(--text); margin-bottom: 8px; letter-spacing: -0.02em; }
+    .synth-desc { font-size: 13px; color: var(--text-muted); line-height: 1.65; }
+
+    /* Tag */
+    .tag {
+      display: inline-flex; align-items: center; padding: 3px 10px;
+      border-radius: 999px; font-size: 11px; font-weight: 700;
+    }
+    .tag.ok { background: rgba(112,225,203,0.1); color: var(--accent-2); border: 1px solid rgba(112,225,203,0.25); }
+    .tag.warn { background: rgba(255,208,114,0.1); color: var(--warning); border: 1px solid rgba(255,208,114,0.25); }
+    .tag.info { background: rgba(104,182,255,0.1); color: var(--accent); border: 1px solid rgba(104,182,255,0.25); }
+
+    @media (max-width: 900px) {
+      .obs-grid { grid-template-columns: repeat(2, 1fr); }
+      .two-col { grid-template-columns: 1fr; }
+      .synth-grid { grid-template-columns: 1fr; }
+    }
+    @media (max-width: 560px) {
+      .obs-grid { grid-template-columns: repeat(2, 1fr); }
+    }
+    @media print {
+      body { background: #fff; color: #111; }
+      .hero, .section { background: #fff; border-color: #ddd; box-shadow: none; }
+    }
+  </style>
+</head>
+<body>
+<main class="page">
+
+  <!-- Hero -->
+  <header class="hero">
+    <div class="eyebrow">Analysis</div>
+    <h1>Auth Response Time<br/>Distribution Analysis</h1>
+    <p style="color:var(--text-muted);font-size:15px;max-width:68ch">
+      Statistical investigation of payment method auth latency — comparing provider-wide benchmarks against merchant-specific observations to determine whether elevated response times indicate a system anomaly.
+    </p>
+    <div class="hero-meta">
+      <div class="meta-item"><strong>Period</strong> Jan – Mar 2026</div>
+      <div class="meta-item"><strong>Dataset</strong> 671,739 transactions (provider-wide) · 142 tx (merchant)</div>
+      <div class="meta-item"><strong>Question</strong> Are observed 52s and 75s auth times anomalous?</div>
+    </div>
+  </header>
+
+  <!-- Section 1: Data context -->
+  <section class="section">
+    <div class="section-head">
+      <h2>Key Observations</h2>
+      <p>Three transactions flagged for investigation against provider-wide distribution.</p>
+    </div>
+    <div class="obs-grid">
+      <div class="obs-card">
+        <div class="obs-label">TX-001 Auth</div>
+        <div class="obs-value" style="color:var(--warning)">52s</div>
+        <div class="obs-sub">Card auth · Stage ②</div>
+      </div>
+      <div class="obs-card">
+        <div class="obs-label">TX-002 Auth</div>
+        <div class="obs-value" style="color:var(--danger)">75s</div>
+        <div class="obs-sub">Card auth · Stage ②</div>
+      </div>
+      <div class="obs-card">
+        <div class="obs-label">TX-003 Auth</div>
+        <div class="obs-value" style="color:var(--accent-2)">59s</div>
+        <div class="obs-sub">Points · single-flow</div>
+      </div>
+      <div class="obs-card">
+        <div class="obs-label">Provider Median</div>
+        <div class="obs-value" style="color:var(--accent)">16s</div>
+        <div class="obs-sub">671,739 tx baseline</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 2: Distribution bar -->
+  <section class="section">
+    <div class="section-head">
+      <h2>Section 1 — Auth Time Distribution</h2>
+      <p>Frequency count by time bucket (0–90s) — provider-wide vs merchant. Vertical markers show observed transaction values.</p>
+    </div>
+    <div class="chart-wrap">
+      <canvas id="distChart" height="200"></canvas>
+      <div class="marker-legend">
+        <div class="marker-item"><div class="marker-line" style="border-color:var(--accent)"></div> Provider-wide</div>
+        <div class="marker-item"><div class="marker-line" style="border-color:var(--accent-2)"></div> Merchant</div>
+        <div class="marker-item"><div class="marker-line" style="border-color:var(--warning)"></div> 52s (TX-001)</div>
+        <div class="marker-item"><div class="marker-line" style="border-color:var(--danger)"></div> 75s (TX-002)</div>
+      </div>
+    </div>
+    <div class="chart-note">
+      Both the provider-wide and merchant distributions are right-skewed. The bulk of transactions complete under 30s.
+      The merchant's tail (60s+) is proportionally wider than the provider benchmark — 5.6% vs 4.4% — consistent with small-merchant variance rather than a system defect.
+    </div>
+  </section>
+
+  <!-- Section 3: Line + dual axis -->
+  <section class="section">
+    <div class="section-head">
+      <h2>Section 2 — 60s+ Tail Rate by Payment Method</h2>
+      <p>Percentage of transactions exceeding 60s across payment methods — provider-wide (bar, left axis) vs merchant (line, right axis).</p>
+    </div>
+    <div class="chart-wrap">
+      <canvas id="tailChart" height="220"></canvas>
+    </div>
+    <div class="chart-note">
+      The 60s+ tail rate pattern is <strong>consistent across payment methods</strong> — not isolated to a single method.
+      The merchant rate tracks the provider curve with a proportional offset, suggesting a client-side environmental factor rather than a payment-method-specific regression.
+    </div>
+  </section>
+
+  <!-- Section 4: Density curve -->
+  <section class="section">
+    <div class="section-head">
+      <h2>Section 3 — Log-Normal Density Fit</h2>
+      <p>Fitted density curves per group. Vertical markers show where observed transactions fall relative to each distribution.</p>
+    </div>
+    <div class="chart-wrap">
+      <canvas id="densityChart" height="220"></canvas>
+      <div class="marker-legend">
+        <div class="marker-item"><div class="marker-line" style="border-color:var(--accent)"></div> Provider distribution</div>
+        <div class="marker-item"><div class="marker-line" style="border-color:var(--accent-2)"></div> Merchant distribution</div>
+        <div class="marker-item"><div class="marker-line" style="border-color:var(--warning)"></div> 52s observation</div>
+        <div class="marker-item"><div class="marker-line" style="border-color:var(--danger)"></div> 75s observation</div>
+      </div>
+    </div>
+    <div class="chart-note">
+      Both 52s (TX-001) and 75s (TX-002) fall <strong>within the merchant's own distribution tail</strong> — they are not outliers relative to the merchant's historical pattern.
+      The provider distribution peaks earlier (~14s) with a tighter spread. The merchant's wider spread is attributable to its smaller transaction volume (142 tx).
+    </div>
+  </section>
+
+  <!-- Section 5: Raw data table -->
+  <section class="section">
+    <div class="section-head">
+      <h2>Section 4 — Transaction Detail</h2>
+      <p>Raw values for the three flagged transactions with stage breakdown and classification.</p>
+    </div>
+    <div class="chart-wrap" style="padding:0;overflow:hidden">
+      <table class="data-table">
+        <thead>
+          <tr>
+            <th>Transaction</th>
+            <th>Method</th>
+            <th>Stage ①③ (API)</th>
+            <th>Stage ② (Auth)</th>
+            <th>Total</th>
+            <th>vs Provider p50</th>
+            <th>Classification</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>TX-001</td>
+            <td>Card</td>
+            <td class="num">21–349 ms</td>
+            <td class="num highlight">52s</td>
+            <td class="num">~53s</td>
+            <td class="num highlight">+225%</td>
+            <td><span class="tag warn">In merchant tail</span></td>
+          </tr>
+          <tr>
+            <td>TX-002</td>
+            <td>Card</td>
+            <td class="num">21–349 ms</td>
+            <td class="num highlight">75s</td>
+            <td class="num">~76s</td>
+            <td class="num highlight">+369%</td>
+            <td><span class="tag warn">In merchant tail</span></td>
+          </tr>
+          <tr>
+            <td>TX-003</td>
+            <td>Points</td>
+            <td class="num">—</td>
+            <td class="num">59s</td>
+            <td class="num">59s</td>
+            <td class="num highlight">+269%</td>
+            <td><span class="tag ok">Single-flow normal</span></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div class="chart-note" style="margin-top:14px">
+      Stage ①③ (Reserve/Approval API calls) are instantaneous in all three cases — <strong>no server-side latency detected</strong>.
+      Stage ② represents user interaction time (card authentication), which is outside server control.
+    </div>
+  </section>
+
+  <!-- Section 6: Synthesis -->
+  <section class="section">
+    <div class="section-head">
+      <h2>Synthesis</h2>
+      <p>Three-axis conclusion: official position, data reality, and environmental signal.</p>
+    </div>
+    <div class="synth-grid">
+      <div class="synth-card">
+        <div class="synth-label" style="color:var(--accent)">Official Position</div>
+        <div class="synth-verdict">No system delay</div>
+        <div class="synth-desc">Provider confirmed: response times reflect user authentication interaction, not API latency. Consistent with Stage ①③ measurements showing sub-350ms API calls.</div>
+      </div>
+      <div class="synth-card">
+        <div class="synth-label" style="color:var(--accent-2)">Data Reality</div>
+        <div class="synth-verdict">Within expected variance</div>
+        <div class="synth-desc">Merchant median (21s) is 31% above the provider benchmark. For a 142-transaction sample, this deviation is within normal small-merchant variance — not statistically significant.</div>
+      </div>
+      <div class="synth-card">
+        <div class="synth-label" style="color:var(--warning)">Environmental Signal</div>
+        <div class="synth-verdict">Client-side factor likely</div>
+        <div class="synth-desc">Cross-method 60s+ outliers (Card 126s, Points 116s, Other 147s) in the same period suggest a shared client-side factor. Reproduction testing recommended before escalation.</div>
+      </div>
+    </div>
+  </section>
+
+</main>
+
+<script>
+Chart.defaults.color = '#98abc9';
+Chart.defaults.borderColor = 'rgba(153,186,255,0.10)';
+Chart.defaults.font.family = '"Inter","Noto Sans KR",sans-serif';
+
+// Shared annotation plugin — vertical dashed lines
+function verticalLinePlugin(markers) {
+  return {
+    id: 'verticalLines',
+    afterDraw(chart) {
+      const ctx = chart.ctx;
+      const xAxis = chart.scales.x;
+      const yAxis = chart.scales.y;
+      if (!xAxis || !yAxis) return;
+      markers.forEach(({ value, color, label }) => {
+        const x = xAxis.getPixelForValue(value);
+        if (x < xAxis.left || x > xAxis.right) return;
+        ctx.save();
+        ctx.beginPath();
+        ctx.setLineDash([5, 4]);
+        ctx.strokeStyle = color;
+        ctx.lineWidth = 1.5;
+        ctx.moveTo(x, yAxis.top);
+        ctx.lineTo(x, yAxis.bottom);
+        ctx.stroke();
+        ctx.setLineDash([]);
+        ctx.fillStyle = color;
+        ctx.font = '600 11px Inter,sans-serif';
+        ctx.textAlign = 'center';
+        ctx.fillText(label, x, yAxis.top - 6);
+        ctx.restore();
+      });
+    }
+  };
+}
+
+// ---------- Chart 1: Distribution bar ----------
+const buckets = ['0–10s','10–20s','20–30s','30–40s','40–50s','50–60s','60–75s','75–90s'];
+const providerPct = [18, 38, 22, 10, 4.4, 3.2, 2.8, 1.6];  // % of transactions
+const merchantPct = [12, 30, 24, 14, 7, 6.4, 4.2, 2.4];
+
+new Chart(document.getElementById('distChart'), {
+  type: 'bar',
+  data: {
+    labels: buckets,
+    datasets: [
+      {
+        label: 'Provider-wide (%)',
+        data: providerPct,
+        backgroundColor: 'rgba(104,182,255,0.25)',
+        borderColor: 'rgba(104,182,255,0.7)',
+        borderWidth: 1.5,
+        borderRadius: 4,
+      },
+      {
+        label: 'Merchant (%)',
+        data: merchantPct,
+        backgroundColor: 'rgba(112,225,203,0.2)',
+        borderColor: 'rgba(112,225,203,0.6)',
+        borderWidth: 1.5,
+        borderRadius: 4,
+      }
+    ]
+  },
+  options: {
+    responsive: true,
+    plugins: {
+      legend: { position: 'top', labels: { boxWidth: 14, padding: 16, font: { size: 12 } } },
+      tooltip: { callbacks: { label: ctx => ` ${ctx.dataset.label}: ${ctx.parsed.y}%` } }
+    },
+    scales: {
+      x: { grid: { color: 'rgba(153,186,255,0.07)' } },
+      y: { grid: { color: 'rgba(153,186,255,0.07)' }, ticks: { callback: v => v + '%' } }
+    }
+  },
+  plugins: [verticalLinePlugin([
+    { value: 5.2, color: 'rgba(255,208,114,0.9)', label: '52s' },
+    { value: 7.1, color: 'rgba(255,140,159,0.9)', label: '75s' },
+  ])]
+});
+
+// ---------- Chart 2: Dual-axis tail rate ----------
+const methods = ['naver_pay','kakao_pay','kr_card','visa','mastercard'];
+const providerTail = [4.4, 3.8, 3.1, 2.2, 2.0];
+const merchantTail = [5.6, 5.1, 4.6, 3.4, 3.1];
+
+new Chart(document.getElementById('tailChart'), {
+  type: 'bar',
+  data: {
+    labels: methods,
+    datasets: [
+      {
+        label: 'Provider 60s+ rate (%)',
+        data: providerTail,
+        backgroundColor: 'rgba(104,182,255,0.22)',
+        borderColor: 'rgba(104,182,255,0.6)',
+        borderWidth: 1.5,
+        borderRadius: 4,
+        yAxisID: 'y',
+      },
+      {
+        type: 'line',
+        label: 'Merchant 60s+ rate (%)',
+        data: merchantTail,
+        borderColor: 'rgba(112,225,203,0.8)',
+        backgroundColor: 'rgba(112,225,203,0.1)',
+        borderWidth: 2,
+        pointRadius: 5,
+        pointBackgroundColor: 'rgba(112,225,203,0.8)',
+        tension: 0.3,
+        fill: true,
+        yAxisID: 'y2',
+      }
+    ]
+  },
+  options: {
+    responsive: true,
+    plugins: {
+      legend: { position: 'top', labels: { boxWidth: 14, padding: 16, font: { size: 12 } } }
+    },
+    scales: {
+      x: { grid: { color: 'rgba(153,186,255,0.07)' } },
+      y:  { position: 'left',  grid: { color: 'rgba(153,186,255,0.07)' }, ticks: { callback: v => v + '%' }, title: { display: true, text: 'Provider (%)', font: { size: 11 } } },
+      y2: { position: 'right', grid: { drawOnChartArea: false }, ticks: { callback: v => v + '%' }, title: { display: true, text: 'Merchant (%)', font: { size: 11 } } }
+    }
+  }
+});
+
+// ---------- Chart 3: Log-normal density ----------
+function logNormal(x, mu, sigma) {
+  if (x <= 0) return 0;
+  const a = 1 / (x * sigma * Math.sqrt(2 * Math.PI));
+  return a * Math.exp(-Math.pow(Math.log(x) - mu, 2) / (2 * sigma * sigma));
+}
+
+const xs = Array.from({ length: 100 }, (_, i) => i + 1);
+const providerDensity = xs.map(x => logNormal(x, Math.log(16), 0.9));
+const merchantDensity = xs.map(x => logNormal(x, Math.log(21), 1.1));
+const maxVal = Math.max(...providerDensity, ...merchantDensity);
+const providerNorm = providerDensity.map(v => v / maxVal);
+const merchantNorm = merchantDensity.map(v => v / maxVal);
+
+new Chart(document.getElementById('densityChart'), {
+  type: 'line',
+  data: {
+    labels: xs,
+    datasets: [
+      {
+        label: 'Provider density',
+        data: providerNorm,
+        borderColor: 'rgba(104,182,255,0.8)',
+        backgroundColor: 'rgba(104,182,255,0.08)',
+        borderWidth: 2,
+        pointRadius: 0,
+        tension: 0.4,
+        fill: true,
+      },
+      {
+        label: 'Merchant density',
+        data: merchantNorm,
+        borderColor: 'rgba(112,225,203,0.8)',
+        backgroundColor: 'rgba(112,225,203,0.07)',
+        borderWidth: 2,
+        pointRadius: 0,
+        tension: 0.4,
+        fill: true,
+      }
+    ]
+  },
+  options: {
+    responsive: true,
+    plugins: {
+      legend: { position: 'top', labels: { boxWidth: 14, padding: 16, font: { size: 12 } } },
+      tooltip: { callbacks: { label: ctx => ` ${ctx.dataset.label}: ${ctx.parsed.y.toFixed(3)}` } }
+    },
+    scales: {
+      x: {
+        grid: { color: 'rgba(153,186,255,0.07)' },
+        ticks: {
+          callback: (_, i) => i % 10 === 0 ? xs[i] + 's' : '',
+          maxRotation: 0
+        },
+        title: { display: true, text: 'Auth time (seconds)', font: { size: 11 } }
+      },
+      y: { display: false }
+    }
+  },
+  plugins: [verticalLinePlugin([
+    { value: 52, color: 'rgba(255,208,114,0.9)', label: '52s' },
+    { value: 75, color: 'rgba(255,140,159,0.9)', label: '75s' },
+  ])]
+});
+</script>
+</body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -164,20 +164,15 @@
     .type-timeline   { background: rgba(104, 182, 255, 0.08); color: #9dd4ff; }
     .type-dashboard  { background: rgba(112, 225, 203, 0.08); color: #8de8d4; }
     .type-deck       { background: rgba(200, 160, 255, 0.1); color: #c8a0ff; }
+    .type-analysis   { background: rgba(255, 208, 114, 0.08); color: #ffd88a; }
 
-    .card.report   { --hover-color: rgba(104, 182, 255, 0.04); }
-    .card.flow     { --hover-color: rgba(112, 225, 203, 0.04); }
-    .card.comparison { --hover-color: rgba(255, 208, 114, 0.04); }
-    .card.timeline   { --hover-color: rgba(104, 182, 255, 0.03); }
-    .card.dashboard  { --hover-color: rgba(112, 225, 203, 0.03); }
-    .card.deck       { --hover-color: rgba(200, 160, 255, 0.04); }
-
-    .card.report:hover   { background: rgba(104, 182, 255, 0.04); }
-    .card.flow:hover     { background: rgba(112, 225, 203, 0.04); }
+    .card.report:hover     { background: rgba(104, 182, 255, 0.04); }
+    .card.flow:hover       { background: rgba(112, 225, 203, 0.04); }
     .card.comparison:hover { background: rgba(255, 208, 114, 0.04); }
     .card.timeline:hover   { background: rgba(104, 182, 255, 0.03); }
     .card.dashboard:hover  { background: rgba(112, 225, 203, 0.03); }
     .card.deck:hover       { background: rgba(200, 160, 255, 0.04); }
+    .card.analysis:hover   { background: rgba(255, 208, 114, 0.04); }
 
     /* Footer */
     .footer {
@@ -285,6 +280,17 @@
         <h3>Q2 Engineering Strategy</h3>
         <p>6-slide presentation deck — title, problem framing, three priorities, principles, OKRs, and closing.</p>
         <div class="card-footer">deck.html</div>
+      </a>
+
+      <a class="card analysis" href="analysis.html">
+        <div class="card-top">
+          <span class="type-badge type-analysis">analysis</span>
+          <span class="arrow">↗</span>
+        </div>
+        <div class="card-icon">📈</div>
+        <h3>Response Time Distribution</h3>
+        <p>Statistical investigation of auth latency — distribution bars, dual-axis tail rate, log-normal density curves, and observed-value markers.</p>
+        <div class="card-footer">analysis.html</div>
       </a>
 
     </div>

--- a/skills/visualize/SKILL.md
+++ b/skills/visualize/SKILL.md
@@ -41,6 +41,7 @@ Convert any document or structured data into a readable, self-contained single H
 | `timeline` | Sequential steps, rollout, incident progression | hero → sequence → milestone details → risk/decision |
 | `dashboard` | KPIs, operational status, snapshot summary | hero → KPI row → supporting cards → notes |
 | `deck` | Presentation, storytelling, section-driven narrative | title slide → section slides → closing |
+| `analysis` | Data-driven investigation — distribution, density, statistical patterns | hero → data context → chart sections → interpretation → synthesis |
 
 **Selection heuristics**:
 - Long text with explanation → `report`
@@ -48,6 +49,7 @@ Convert any document or structured data into a readable, self-contained single H
 - Core is difference or tradeoff → `comparison`
 - Core is numbers or status → `dashboard`
 - Core is narrative or presentation → `deck`
+- Core is actual data with charts, distributions, or statistical patterns → `analysis`
 - When unsure, use `report` and mix in a `flow` or `comparison` section.
 
 Don't mix three or more types. Pick one primary type and add secondary patterns sparingly.
@@ -66,10 +68,32 @@ Don't mix three or more types. Pick one primary type and add secondary patterns 
 
 **Interaction**: Only add filter/tab/toggle if it aids understanding. Core information must be visible in the default state.
 
+## Analysis Type — Additional Rules
+
+Use `analysis` when the core deliverable is data-driven charts with statistical interpretation, not prose or process flows.
+
+**Structure**:
+1. `hero` — data source, period, and the question being answered
+2. Data context section — observation cards (key values, what was measured)
+3. Chart sections — one question per section, chart first then interpretation below
+4. Interpretation section — what the data shows, anomalies, notable patterns
+5. Synthesis section — 2–4 cards summarizing the conclusion per axis
+
+**Chart patterns** (use Chart.js for this type by default):
+- Distribution bar — frequency counts per bucket
+- Line + dual-axis — compare two scales (e.g., count vs percentage)
+- Density curve — log-normal or KDE fit with observed-value vertical markers
+- Stacked bar — composition across categories
+- Data table — raw values alongside charts when precision matters
+
+**Marker convention**: observed values (specific transactions, incidents) are shown as vertical dashed lines with labeled callouts — never buried in prose.
+
+**Interpretation placement**: one short paragraph directly below each chart. Do not save all interpretation for the end.
+
 ## Libraries
 
 Vanilla HTML/CSS/JS by default. Add libraries only when genuinely needed:
-- `Chart.js` — only when actual chart rendering is required
+- `Chart.js` — default for `analysis` type; optional for other types
 - `Mermaid` — only for quick flowcharts or sequences
 - `Reveal.js` — only for deck type with explicit slide navigation
 


### PR DESCRIPTION
## 변경 내용

### SKILL.md
- `analysis` 타입 추가 (7번째)
- Analysis Type 전용 규칙 섹션 추가 (구조, 차트 패턴, 마커 컨벤션, 해석 배치)
- Libraries 섹션: Chart.js가 analysis 타입 기본 탑재임을 명시

### examples/analysis.html
ISS-038 Naver Pay 패턴 기반 샘플:
- Section 1: 관찰 트랜잭션 4종 KPI 카드
- Section 2: 분포 바 차트 (provider vs merchant, 52s·75s 수직 마커)
- Section 3: 60s+ tail rate 듀얼축 차트 (바 + 라인)
- Section 4: log-normal 밀도 커브 (52s·75s 수직 마커)
- Section 5: 원시 데이터 테이블
- Section 6: 3-축 종합 카드 (공식 입장·데이터 현실·환경 신호)

### 파생 업데이트
- `examples/index.html` — analysis 카드 추가
- `README.md` / `README.ko.md` — 타입 테이블 및 샘플 테이블에 analysis 추가

Closes #8