### PR TITLE
fix: realistic fake data for analysis.html

### DIFF
--- a/examples/analysis.html
+++ b/examples/analysis.html
@@ -12,7 +12,6 @@
     :root {
       color-scheme: dark;
       --surface: rgba(12, 21, 36, 0.92);
-      --surface-2: rgba(16, 28, 46, 0.96);
       --border: rgba(153, 186, 255, 0.14);
       --border-strong: rgba(153, 186, 255, 0.28);
       --text: #edf3ff;
@@ -21,7 +20,6 @@
       --accent-2: #70e1cb;
       --danger: #ff8c9f;
       --warning: #ffd072;
-      --purple: #c8a0ff;
       --radius-xl: 28px;
       --radius-lg: 20px;
       --radius-md: 14px;
@@ -44,7 +42,6 @@
     .page { width: min(var(--max), calc(100% - 32px)); margin: 0 auto; padding: 28px 0 64px; }
     main { display: grid; gap: 18px; }
 
-    /* Hero */
     .hero {
       border: 1px solid var(--border);
       background: linear-gradient(180deg, rgba(15,27,44,0.98), rgba(8,15,28,0.94));
@@ -56,12 +53,18 @@
       border: 1px solid rgba(104,182,255,0.2); background: rgba(104,182,255,0.08);
       color: #c2ddff; font-size: 12px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase;
     }
+    .sample-badge {
+      display: inline-flex; align-items: center; gap: 6px;
+      padding: 5px 12px; border-radius: 999px; margin-left: 10px;
+      border: 1px solid rgba(255,208,114,0.3); background: rgba(255,208,114,0.08);
+      color: var(--warning); font-size: 11px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase;
+      vertical-align: middle;
+    }
     h1 { margin: 0 0 14px; font-size: clamp(2rem, 4vw, 3.2rem); line-height: 1.08; letter-spacing: -0.035em; font-weight: 900; }
     .hero-meta { display: flex; flex-wrap: wrap; gap: 20px; margin-top: 20px; }
     .meta-item { font-size: 13px; color: var(--text-muted); }
     .meta-item strong { color: var(--text); font-weight: 600; }
 
-    /* Section */
     .section {
       border: 1px solid var(--border); background: var(--surface);
       border-radius: var(--radius-xl); padding: 26px; box-shadow: var(--shadow);
@@ -72,7 +75,6 @@
     h3 { margin: 0 0 8px; font-size: 1.05rem; letter-spacing: -0.02em; font-weight: 700; }
     p { margin: 0; color: var(--text-muted); font-size: 15px; }
 
-    /* Observation cards */
     .obs-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; }
     .obs-card {
       border: 1px solid var(--border); border-radius: var(--radius-md);
@@ -82,14 +84,12 @@
     .obs-value { font-size: 1.6rem; font-weight: 800; letter-spacing: -0.04em; line-height: 1; }
     .obs-sub { font-size: 12px; color: var(--text-muted); margin-top: 6px; }
 
-    /* Chart wrapper */
     .chart-wrap {
       position: relative; width: 100%;
       background: rgba(255,255,255,0.02);
       border: 1px solid var(--border); border-radius: var(--radius-md);
       padding: 20px;
     }
-    .chart-wrap canvas { display: block; }
     .chart-note {
       margin-top: 14px; padding: 12px 16px;
       border-radius: 10px; background: rgba(255,255,255,0.03);
@@ -98,10 +98,8 @@
     }
     .chart-note strong { color: var(--text); }
 
-    /* Two col */
     .two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
 
-    /* Data table */
     .data-table { width: 100%; border-collapse: collapse; font-size: 13px; }
     .data-table th {
       text-align: left; padding: 10px 14px;
@@ -111,43 +109,33 @@
     .data-table td { padding: 10px 14px; border-bottom: 1px solid rgba(153,186,255,0.07); color: var(--text-muted); }
     .data-table tr:last-child td { border-bottom: none; }
     .data-table td.num { font-weight: 600; color: var(--text); text-align: right; font-variant-numeric: tabular-nums; }
-    .data-table td.highlight { color: var(--warning); font-weight: 700; }
-    .data-table td.ok { color: var(--accent-2); font-weight: 600; }
+    .data-table td.hi  { color: var(--warning); font-weight: 700; text-align: right; }
+    .data-table td.ok  { color: var(--accent-2); font-weight: 600; }
 
-    /* Marker legend */
     .marker-legend { display: flex; flex-wrap: wrap; gap: 16px; margin-top: 12px; }
     .marker-item { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--text-muted); }
     .marker-line { width: 24px; height: 2px; border-top: 2px dashed; }
 
-    /* Synthesis cards */
     .synth-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; }
     .synth-card {
       border: 1px solid var(--border); border-radius: var(--radius-lg);
       padding: 20px; background: rgba(255,255,255,0.03);
     }
-    .synth-label {
-      font-size: 11px; font-weight: 800; letter-spacing: 0.08em; text-transform: uppercase;
-      margin-bottom: 10px;
-    }
+    .synth-label { font-size: 11px; font-weight: 800; letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 10px; }
     .synth-verdict { font-size: 15px; font-weight: 700; color: var(--text); margin-bottom: 8px; letter-spacing: -0.02em; }
     .synth-desc { font-size: 13px; color: var(--text-muted); line-height: 1.65; }
 
-    /* Tag */
     .tag {
       display: inline-flex; align-items: center; padding: 3px 10px;
       border-radius: 999px; font-size: 11px; font-weight: 700;
     }
-    .tag.ok { background: rgba(112,225,203,0.1); color: var(--accent-2); border: 1px solid rgba(112,225,203,0.25); }
-    .tag.warn { background: rgba(255,208,114,0.1); color: var(--warning); border: 1px solid rgba(255,208,114,0.25); }
-    .tag.info { background: rgba(104,182,255,0.1); color: var(--accent); border: 1px solid rgba(104,182,255,0.25); }
+    .tag.ok   { background: rgba(112,225,203,0.1); color: var(--accent-2); border: 1px solid rgba(112,225,203,0.25); }
+    .tag.warn { background: rgba(255,208,114,0.1); color: var(--warning);  border: 1px solid rgba(255,208,114,0.25); }
 
     @media (max-width: 900px) {
-      .obs-grid { grid-template-columns: repeat(2, 1fr); }
-      .two-col { grid-template-columns: 1fr; }
-      .synth-grid { grid-template-columns: 1fr; }
-    }
-    @media (max-width: 560px) {
-      .obs-grid { grid-template-columns: repeat(2, 1fr); }
+      .obs-grid  { grid-template-columns: repeat(2, 1fr); }
+      .two-col   { grid-template-columns: 1fr; }
+      .synth-grid{ grid-template-columns: 1fr; }
     }
     @media print {
       body { background: #fff; color: #111; }
@@ -160,249 +148,264 @@
 
   <!-- Hero -->
   <header class="hero">
-    <div class="eyebrow">Analysis</div>
+    <div>
+      <div class="eyebrow">Analysis</div>
+      <span class="sample-badge">⚠ Sample Data</span>
+    </div>
     <h1>Auth Response Time<br/>Distribution Analysis</h1>
     <p style="color:var(--text-muted);font-size:15px;max-width:68ch">
-      Statistical investigation of payment method auth latency — comparing provider-wide benchmarks against merchant-specific observations to determine whether elevated response times indicate a system anomaly.
+      Statistical investigation of payment auth latency — comparing benchmark distribution against merchant-specific observations to determine whether elevated response times indicate a system anomaly.
     </p>
     <div class="hero-meta">
-      <div class="meta-item"><strong>Period</strong> Jan – Mar 2026</div>
-      <div class="meta-item"><strong>Dataset</strong> 671,739 transactions (provider-wide) · 142 tx (merchant)</div>
-      <div class="meta-item"><strong>Question</strong> Are observed 52s and 75s auth times anomalous?</div>
+      <div class="meta-item"><strong>Period</strong> Jan – Mar 2026 (sample)</div>
+      <div class="meta-item"><strong>Dataset</strong> 524,821 tx (benchmark) · 318 tx (merchant)</div>
+      <div class="meta-item"><strong>Question</strong> Are 48s and 83s observations anomalous?</div>
     </div>
   </header>
 
-  <!-- Section 1: Data context -->
+  <!-- Key observations -->
   <section class="section">
     <div class="section-head">
       <h2>Key Observations</h2>
-      <p>Three transactions flagged for investigation against provider-wide distribution.</p>
+      <p>Three transactions flagged during investigation against benchmark distribution.</p>
     </div>
     <div class="obs-grid">
       <div class="obs-card">
-        <div class="obs-label">TX-001 Auth</div>
-        <div class="obs-value" style="color:var(--warning)">52s</div>
-        <div class="obs-sub">Card auth · Stage ②</div>
+        <div class="obs-label">OBS-A Auth</div>
+        <div class="obs-value" style="color:var(--warning)">48s</div>
+        <div class="obs-sub">Card auth · user interaction</div>
       </div>
       <div class="obs-card">
-        <div class="obs-label">TX-002 Auth</div>
-        <div class="obs-value" style="color:var(--danger)">75s</div>
-        <div class="obs-sub">Card auth · Stage ②</div>
+        <div class="obs-label">OBS-B Auth</div>
+        <div class="obs-value" style="color:var(--danger)">83s</div>
+        <div class="obs-sub">Card auth · user interaction</div>
       </div>
       <div class="obs-card">
-        <div class="obs-label">TX-003 Auth</div>
-        <div class="obs-value" style="color:var(--accent-2)">59s</div>
-        <div class="obs-sub">Points · single-flow</div>
+        <div class="obs-label">OBS-C Auth</div>
+        <div class="obs-value" style="color:var(--accent-2)">62s</div>
+        <div class="obs-sub">Wallet · single-flow</div>
       </div>
       <div class="obs-card">
-        <div class="obs-label">Provider Median</div>
-        <div class="obs-value" style="color:var(--accent)">16s</div>
-        <div class="obs-sub">671,739 tx baseline</div>
+        <div class="obs-label">Benchmark Median</div>
+        <div class="obs-value" style="color:var(--accent)">14s</div>
+        <div class="obs-sub">524,821 tx baseline</div>
       </div>
     </div>
   </section>
 
-  <!-- Section 2: Distribution bar -->
+  <!-- Section 1: Distribution bar -->
   <section class="section">
     <div class="section-head">
       <h2>Section 1 — Auth Time Distribution</h2>
-      <p>Frequency count by time bucket (0–90s) — provider-wide vs merchant. Vertical markers show observed transaction values.</p>
+      <p>Transaction share by time bucket (0–90s). Vertical markers show where observed values fall.</p>
     </div>
     <div class="chart-wrap">
       <canvas id="distChart" height="200"></canvas>
       <div class="marker-legend">
-        <div class="marker-item"><div class="marker-line" style="border-color:var(--accent)"></div> Provider-wide</div>
+        <div class="marker-item"><div class="marker-line" style="border-color:var(--accent)"></div> Benchmark</div>
         <div class="marker-item"><div class="marker-line" style="border-color:var(--accent-2)"></div> Merchant</div>
-        <div class="marker-item"><div class="marker-line" style="border-color:var(--warning)"></div> 52s (TX-001)</div>
-        <div class="marker-item"><div class="marker-line" style="border-color:var(--danger)"></div> 75s (TX-002)</div>
+        <div class="marker-item"><div class="marker-line" style="border-color:var(--warning)"></div> 48s (OBS-A)</div>
+        <div class="marker-item"><div class="marker-line" style="border-color:var(--danger)"></div> 83s (OBS-B)</div>
       </div>
     </div>
     <div class="chart-note">
-      Both the provider-wide and merchant distributions are right-skewed. The bulk of transactions complete under 30s.
-      The merchant's tail (60s+) is proportionally wider than the provider benchmark — 5.6% vs 4.4% — consistent with small-merchant variance rather than a system defect.
+      Both distributions are right-skewed with a long tail beyond 40s. The merchant tail (60s+) accounts for <strong>6.3%</strong> of transactions vs the benchmark's <strong>3.9%</strong> — a 61% relative elevation that is within expected variance for a 318-transaction sample.
     </div>
   </section>
 
-  <!-- Section 3: Line + dual axis -->
+  <!-- Section 2: Dual-axis tail rate -->
   <section class="section">
     <div class="section-head">
       <h2>Section 2 — 60s+ Tail Rate by Payment Method</h2>
-      <p>Percentage of transactions exceeding 60s across payment methods — provider-wide (bar, left axis) vs merchant (line, right axis).</p>
+      <p>Percentage of transactions exceeding 60s — benchmark (bar, left axis) vs merchant (line, right axis).</p>
     </div>
     <div class="chart-wrap">
       <canvas id="tailChart" height="220"></canvas>
     </div>
     <div class="chart-note">
-      The 60s+ tail rate pattern is <strong>consistent across payment methods</strong> — not isolated to a single method.
-      The merchant rate tracks the provider curve with a proportional offset, suggesting a client-side environmental factor rather than a payment-method-specific regression.
+      The elevated tail rate is <strong>not isolated to a single payment method</strong> — it appears consistently across card, wallet, and bank transfer. This cross-method pattern points to a client-side environmental factor rather than a method-specific regression.
     </div>
   </section>
 
-  <!-- Section 4: Density curve -->
+  <!-- Section 3: Density curves -->
   <section class="section">
     <div class="section-head">
       <h2>Section 3 — Log-Normal Density Fit</h2>
-      <p>Fitted density curves per group. Vertical markers show where observed transactions fall relative to each distribution.</p>
+      <p>Fitted density curves for both groups. Vertical markers show where the three flagged observations fall.</p>
     </div>
     <div class="chart-wrap">
       <canvas id="densityChart" height="220"></canvas>
       <div class="marker-legend">
-        <div class="marker-item"><div class="marker-line" style="border-color:var(--accent)"></div> Provider distribution</div>
+        <div class="marker-item"><div class="marker-line" style="border-color:var(--accent)"></div> Benchmark distribution</div>
         <div class="marker-item"><div class="marker-line" style="border-color:var(--accent-2)"></div> Merchant distribution</div>
-        <div class="marker-item"><div class="marker-line" style="border-color:var(--warning)"></div> 52s observation</div>
-        <div class="marker-item"><div class="marker-line" style="border-color:var(--danger)"></div> 75s observation</div>
+        <div class="marker-item"><div class="marker-line" style="border-color:var(--warning)"></div> 48s (OBS-A)</div>
+        <div class="marker-item"><div class="marker-line" style="border-color:var(--danger)"></div> 83s (OBS-B)</div>
       </div>
     </div>
     <div class="chart-note">
-      Both 52s (TX-001) and 75s (TX-002) fall <strong>within the merchant's own distribution tail</strong> — they are not outliers relative to the merchant's historical pattern.
-      The provider distribution peaks earlier (~14s) with a tighter spread. The merchant's wider spread is attributable to its smaller transaction volume (142 tx).
+      OBS-A (48s) and OBS-B (83s) both fall <strong>within the merchant distribution tail</strong> — they are not statistical outliers relative to this merchant's own historical pattern. The merchant distribution (μ=ln 19, σ=1.05) has a heavier tail than the benchmark (μ=ln 14, σ=0.82) due to smaller sample size.
     </div>
   </section>
 
-  <!-- Section 5: Raw data table -->
+  <!-- Section 4: Raw data table -->
   <section class="section">
     <div class="section-head">
-      <h2>Section 4 — Transaction Detail</h2>
-      <p>Raw values for the three flagged transactions with stage breakdown and classification.</p>
+      <h2>Section 4 — Observation Detail</h2>
+      <p>Breakdown of the three flagged transactions with API stage timing and classification.</p>
     </div>
     <div class="chart-wrap" style="padding:0;overflow:hidden">
       <table class="data-table">
         <thead>
           <tr>
-            <th>Transaction</th>
+            <th>Observation</th>
             <th>Method</th>
-            <th>Stage ①③ (API)</th>
-            <th>Stage ② (Auth)</th>
+            <th>API stages (ms)</th>
+            <th>Auth stage</th>
             <th>Total</th>
-            <th>vs Provider p50</th>
+            <th>vs benchmark p50</th>
             <th>Classification</th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td>TX-001</td>
+            <td>OBS-A</td>
             <td>Card</td>
-            <td class="num">21–349 ms</td>
-            <td class="num highlight">52s</td>
-            <td class="num">~53s</td>
-            <td class="num highlight">+225%</td>
-            <td><span class="tag warn">In merchant tail</span></td>
+            <td class="num">18–412 ms</td>
+            <td class="hi">48s</td>
+            <td class="num">~49s</td>
+            <td class="hi">+243%</td>
+            <td><span class="tag warn">Within merchant tail</span></td>
           </tr>
           <tr>
-            <td>TX-002</td>
+            <td>OBS-B</td>
             <td>Card</td>
-            <td class="num">21–349 ms</td>
-            <td class="num highlight">75s</td>
-            <td class="num">~76s</td>
-            <td class="num highlight">+369%</td>
-            <td><span class="tag warn">In merchant tail</span></td>
+            <td class="num">22–389 ms</td>
+            <td class="hi">83s</td>
+            <td class="num">~84s</td>
+            <td class="hi">+493%</td>
+            <td><span class="tag warn">Within merchant tail</span></td>
           </tr>
           <tr>
-            <td>TX-003</td>
-            <td>Points</td>
+            <td>OBS-C</td>
+            <td>Wallet</td>
             <td class="num">—</td>
-            <td class="num">59s</td>
-            <td class="num">59s</td>
-            <td class="num highlight">+269%</td>
+            <td class="num">62s</td>
+            <td class="num">62s</td>
+            <td class="hi">+343%</td>
             <td><span class="tag ok">Single-flow normal</span></td>
           </tr>
         </tbody>
       </table>
     </div>
     <div class="chart-note" style="margin-top:14px">
-      Stage ①③ (Reserve/Approval API calls) are instantaneous in all three cases — <strong>no server-side latency detected</strong>.
-      Stage ② represents user interaction time (card authentication), which is outside server control.
+      API stages (Reserve / Approval calls) complete in <strong>under 500ms</strong> for all three observations — no server-side latency detected. The auth stage reflects user interaction time, which is outside server control.
     </div>
   </section>
 
-  <!-- Section 6: Synthesis -->
+  <!-- Section 5: Synthesis -->
   <section class="section">
     <div class="section-head">
       <h2>Synthesis</h2>
-      <p>Three-axis conclusion: official position, data reality, and environmental signal.</p>
+      <p>Three-axis conclusion from the analysis.</p>
     </div>
     <div class="synth-grid">
       <div class="synth-card">
         <div class="synth-label" style="color:var(--accent)">Official Position</div>
-        <div class="synth-verdict">No system delay</div>
-        <div class="synth-desc">Provider confirmed: response times reflect user authentication interaction, not API latency. Consistent with Stage ①③ measurements showing sub-350ms API calls.</div>
+        <div class="synth-verdict">No system delay confirmed</div>
+        <div class="synth-desc">Provider confirmed response times reflect user authentication interaction, not API processing. Consistent with sub-500ms API stage measurements across all three observations.</div>
       </div>
       <div class="synth-card">
         <div class="synth-label" style="color:var(--accent-2)">Data Reality</div>
-        <div class="synth-verdict">Within expected variance</div>
-        <div class="synth-desc">Merchant median (21s) is 31% above the provider benchmark. For a 142-transaction sample, this deviation is within normal small-merchant variance — not statistically significant.</div>
+        <div class="synth-verdict">Elevated but within variance</div>
+        <div class="synth-desc">Merchant median (19s) is 36% above the benchmark. For a 318-transaction sample, this spread falls within expected small-merchant variance — not statistically significant at 95% confidence.</div>
       </div>
       <div class="synth-card">
         <div class="synth-label" style="color:var(--warning)">Environmental Signal</div>
         <div class="synth-verdict">Client-side factor likely</div>
-        <div class="synth-desc">Cross-method 60s+ outliers (Card 126s, Points 116s, Other 147s) in the same period suggest a shared client-side factor. Reproduction testing recommended before escalation.</div>
+        <div class="synth-desc">Cross-method elevation pattern (card, wallet, bank transfer all elevated) suggests a shared client-side factor. Recommend reproduction testing in an isolated environment before further escalation.</div>
       </div>
     </div>
   </section>
 
 </main>
-
 <script>
 Chart.defaults.color = '#98abc9';
 Chart.defaults.borderColor = 'rgba(153,186,255,0.10)';
 Chart.defaults.font.family = '"Inter","Noto Sans KR",sans-serif';
 
-// Shared annotation plugin — vertical dashed lines
-function verticalLinePlugin(markers) {
+// Vertical dashed line plugin
+function vLinePlugin(markers) {
   return {
-    id: 'verticalLines',
+    id: 'vLines',
     afterDraw(chart) {
-      const ctx = chart.ctx;
-      const xAxis = chart.scales.x;
-      const yAxis = chart.scales.y;
-      if (!xAxis || !yAxis) return;
+      const { ctx, scales: { x, y } } = chart;
+      if (!x || !y) return;
       markers.forEach(({ value, color, label }) => {
-        const x = xAxis.getPixelForValue(value);
-        if (x < xAxis.left || x > xAxis.right) return;
+        const px = x.getPixelForValue(value);
+        if (px < x.left || px > x.right) return;
         ctx.save();
         ctx.beginPath();
         ctx.setLineDash([5, 4]);
         ctx.strokeStyle = color;
-        ctx.lineWidth = 1.5;
-        ctx.moveTo(x, yAxis.top);
-        ctx.lineTo(x, yAxis.bottom);
+        ctx.lineWidth = 1.8;
+        ctx.moveTo(px, y.top);
+        ctx.lineTo(px, y.bottom);
         ctx.stroke();
         ctx.setLineDash([]);
         ctx.fillStyle = color;
         ctx.font = '600 11px Inter,sans-serif';
         ctx.textAlign = 'center';
-        ctx.fillText(label, x, yAxis.top - 6);
+        ctx.fillText(label, px, y.top - 7);
         ctx.restore();
       });
     }
   };
 }
 
-// ---------- Chart 1: Distribution bar ----------
-const buckets = ['0–10s','10–20s','20–30s','30–40s','40–50s','50–60s','60–75s','75–90s'];
-const providerPct = [18, 38, 22, 10, 4.4, 3.2, 2.8, 1.6];  // % of transactions
-const merchantPct = [12, 30, 24, 14, 7, 6.4, 4.2, 2.4];
+// Log-normal helper
+function logNorm(x, mu, sigma) {
+  if (x <= 0) return 0;
+  return (1 / (x * sigma * Math.sqrt(2 * Math.PI))) *
+    Math.exp(-Math.pow(Math.log(x) - mu, 2) / (2 * sigma * sigma));
+}
 
+// Bucket boundaries: 0-5, 5-10, 10-15, 15-20, 20-25, 25-30, 30-40, 40-50, 50-65, 65-90
+const bucketLabels = ['0–5s','5–10s','10–15s','15–20s','20–25s','25–30s','30–40s','40–50s','50–65s','65–90s'];
+const bucketMids   = [2.5, 7.5, 12.5, 17.5, 22.5, 27.5, 35, 45, 57.5, 77.5];
+const bucketWidths = [5, 5, 5, 5, 5, 5, 10, 10, 15, 25];
+
+// Benchmark: μ=ln(14), σ=0.82  →  sampled from 524,821 tx
+const benchmarkMu = Math.log(14), benchmarkSig = 0.82;
+const merchantMu  = Math.log(19), merchantSig  = 1.05;
+
+function toPct(mu, sigma, mids, widths) {
+  const raw = mids.map((x, i) => logNorm(x, mu, sigma) * widths[i]);
+  const sum = raw.reduce((a, b) => a + b, 0);
+  return raw.map(v => +((v / sum) * 100).toFixed(1));
+}
+
+const benchmarkDist = toPct(benchmarkMu, benchmarkSig, bucketMids, bucketWidths);
+const merchantDist  = toPct(merchantMu,  merchantSig,  bucketMids, bucketWidths);
+
+// ── Chart 1: Distribution bar ──────────────────────────────────────────────
 new Chart(document.getElementById('distChart'), {
   type: 'bar',
   data: {
-    labels: buckets,
+    labels: bucketLabels,
     datasets: [
       {
-        label: 'Provider-wide (%)',
-        data: providerPct,
-        backgroundColor: 'rgba(104,182,255,0.25)',
-        borderColor: 'rgba(104,182,255,0.7)',
-        borderWidth: 1.5,
-        borderRadius: 4,
+        label: 'Benchmark (%)',
+        data: benchmarkDist,
+        backgroundColor: 'rgba(104,182,255,0.22)',
+        borderColor: 'rgba(104,182,255,0.65)',
+        borderWidth: 1.5, borderRadius: 4,
       },
       {
         label: 'Merchant (%)',
-        data: merchantPct,
-        backgroundColor: 'rgba(112,225,203,0.2)',
-        borderColor: 'rgba(112,225,203,0.6)',
-        borderWidth: 1.5,
-        borderRadius: 4,
+        data: merchantDist,
+        backgroundColor: 'rgba(112,225,203,0.18)',
+        borderColor: 'rgba(112,225,203,0.55)',
+        borderWidth: 1.5, borderRadius: 4,
       }
     ]
   },
@@ -410,23 +413,40 @@ new Chart(document.getElementById('distChart'), {
     responsive: true,
     plugins: {
       legend: { position: 'top', labels: { boxWidth: 14, padding: 16, font: { size: 12 } } },
-      tooltip: { callbacks: { label: ctx => ` ${ctx.dataset.label}: ${ctx.parsed.y}%` } }
+      tooltip: { callbacks: { label: c => ` ${c.dataset.label}: ${c.parsed.y}%` } }
     },
     scales: {
       x: { grid: { color: 'rgba(153,186,255,0.07)' } },
       y: { grid: { color: 'rgba(153,186,255,0.07)' }, ticks: { callback: v => v + '%' } }
     }
   },
-  plugins: [verticalLinePlugin([
-    { value: 5.2, color: 'rgba(255,208,114,0.9)', label: '52s' },
-    { value: 7.1, color: 'rgba(255,140,159,0.9)', label: '75s' },
+  plugins: [vLinePlugin([
+    // bucket index ≈ continuous axis value index
+    { value: 7.6,  color: 'rgba(255,208,114,0.9)', label: '48s' },
+    { value: 9.15, color: 'rgba(255,140,159,0.9)', label: '83s' },
   ])]
 });
 
-// ---------- Chart 2: Dual-axis tail rate ----------
-const methods = ['naver_pay','kakao_pay','kr_card','visa','mastercard'];
-const providerTail = [4.4, 3.8, 3.1, 2.2, 2.0];
-const merchantTail = [5.6, 5.1, 4.6, 3.4, 3.1];
+// ── Chart 2: Dual-axis tail rate ───────────────────────────────────────────
+const methods = ['Card','Wallet','Bank transfer','Prepaid','Other'];
+// Benchmark 60s+ rates derived from logNormal CDF complement
+function tailRate(mu, sigma, cutoff) {
+  // Numerical integration of 1 - CDF
+  let sum = 0;
+  for (let x = cutoff; x <= 300; x += 0.5) {
+    sum += logNorm(x, mu, sigma) * 0.5;
+  }
+  return +(sum * 100).toFixed(2);
+}
+
+// Slightly varied per method by adjusting sigma
+const bSigs = [0.82, 0.78, 0.88, 0.95, 0.91];
+const mSigs = [1.05, 0.98, 1.12, 1.18, 1.09];
+const bMus  = [Math.log(14), Math.log(13), Math.log(15), Math.log(16), Math.log(14.5)];
+const mMus  = [Math.log(19), Math.log(17), Math.log(21), Math.log(22), Math.log(20)];
+
+const benchTail = bMus.map((mu, i) => tailRate(mu, bSigs[i], 60));
+const mercTail  = mMus.map((mu, i) => tailRate(mu, mSigs[i], 60));
 
 new Chart(document.getElementById('tailChart'), {
   type: 'bar',
@@ -434,25 +454,22 @@ new Chart(document.getElementById('tailChart'), {
     labels: methods,
     datasets: [
       {
-        label: 'Provider 60s+ rate (%)',
-        data: providerTail,
+        label: 'Benchmark 60s+ (%)',
+        data: benchTail,
         backgroundColor: 'rgba(104,182,255,0.22)',
         borderColor: 'rgba(104,182,255,0.6)',
-        borderWidth: 1.5,
-        borderRadius: 4,
+        borderWidth: 1.5, borderRadius: 4,
         yAxisID: 'y',
       },
       {
         type: 'line',
-        label: 'Merchant 60s+ rate (%)',
-        data: merchantTail,
-        borderColor: 'rgba(112,225,203,0.8)',
-        backgroundColor: 'rgba(112,225,203,0.1)',
-        borderWidth: 2,
-        pointRadius: 5,
-        pointBackgroundColor: 'rgba(112,225,203,0.8)',
-        tension: 0.3,
-        fill: true,
+        label: 'Merchant 60s+ (%)',
+        data: mercTail,
+        borderColor: 'rgba(112,225,203,0.85)',
+        backgroundColor: 'rgba(112,225,203,0.08)',
+        borderWidth: 2.5,
+        pointRadius: 5, pointBackgroundColor: 'rgba(112,225,203,0.85)',
+        tension: 0.35, fill: true,
         yAxisID: 'y2',
       }
     ]
@@ -460,29 +477,24 @@ new Chart(document.getElementById('tailChart'), {
   options: {
     responsive: true,
     plugins: {
-      legend: { position: 'top', labels: { boxWidth: 14, padding: 16, font: { size: 12 } } }
+      legend: { position: 'top', labels: { boxWidth: 14, padding: 16, font: { size: 12 } } },
+      tooltip: { callbacks: { label: c => ` ${c.dataset.label}: ${c.parsed.y}%` } }
     },
     scales: {
-      x: { grid: { color: 'rgba(153,186,255,0.07)' } },
-      y:  { position: 'left',  grid: { color: 'rgba(153,186,255,0.07)' }, ticks: { callback: v => v + '%' }, title: { display: true, text: 'Provider (%)', font: { size: 11 } } },
+      x:  { grid: { color: 'rgba(153,186,255,0.07)' } },
+      y:  { position: 'left',  grid: { color: 'rgba(153,186,255,0.07)' }, ticks: { callback: v => v + '%' }, title: { display: true, text: 'Benchmark (%)', font: { size: 11 } } },
       y2: { position: 'right', grid: { drawOnChartArea: false }, ticks: { callback: v => v + '%' }, title: { display: true, text: 'Merchant (%)', font: { size: 11 } } }
     }
   }
 });
 
-// ---------- Chart 3: Log-normal density ----------
-function logNormal(x, mu, sigma) {
-  if (x <= 0) return 0;
-  const a = 1 / (x * sigma * Math.sqrt(2 * Math.PI));
-  return a * Math.exp(-Math.pow(Math.log(x) - mu, 2) / (2 * sigma * sigma));
-}
-
-const xs = Array.from({ length: 100 }, (_, i) => i + 1);
-const providerDensity = xs.map(x => logNormal(x, Math.log(16), 0.9));
-const merchantDensity = xs.map(x => logNormal(x, Math.log(21), 1.1));
-const maxVal = Math.max(...providerDensity, ...merchantDensity);
-const providerNorm = providerDensity.map(v => v / maxVal);
-const merchantNorm = merchantDensity.map(v => v / maxVal);
+// ── Chart 3: Density curves ────────────────────────────────────────────────
+const xs = Array.from({ length: 120 }, (_, i) => i + 1);
+const bDens = xs.map(x => logNorm(x, benchmarkMu, benchmarkSig));
+const mDens = xs.map(x => logNorm(x, merchantMu,  merchantSig));
+const peak  = Math.max(...bDens, ...mDens);
+const bNorm = bDens.map(v => v / peak);
+const mNorm = mDens.map(v => v / peak);
 
 new Chart(document.getElementById('densityChart'), {
   type: 'line',
@@ -490,24 +502,18 @@ new Chart(document.getElementById('densityChart'), {
     labels: xs,
     datasets: [
       {
-        label: 'Provider density',
-        data: providerNorm,
-        borderColor: 'rgba(104,182,255,0.8)',
-        backgroundColor: 'rgba(104,182,255,0.08)',
-        borderWidth: 2,
-        pointRadius: 0,
-        tension: 0.4,
-        fill: true,
+        label: 'Benchmark density',
+        data: bNorm,
+        borderColor: 'rgba(104,182,255,0.85)',
+        backgroundColor: 'rgba(104,182,255,0.09)',
+        borderWidth: 2.5, pointRadius: 0, tension: 0.4, fill: true,
       },
       {
         label: 'Merchant density',
-        data: merchantNorm,
-        borderColor: 'rgba(112,225,203,0.8)',
+        data: mNorm,
+        borderColor: 'rgba(112,225,203,0.85)',
         backgroundColor: 'rgba(112,225,203,0.07)',
-        borderWidth: 2,
-        pointRadius: 0,
-        tension: 0.4,
-        fill: true,
+        borderWidth: 2.5, pointRadius: 0, tension: 0.4, fill: true,
       }
     ]
   },
@@ -515,23 +521,20 @@ new Chart(document.getElementById('densityChart'), {
     responsive: true,
     plugins: {
       legend: { position: 'top', labels: { boxWidth: 14, padding: 16, font: { size: 12 } } },
-      tooltip: { callbacks: { label: ctx => ` ${ctx.dataset.label}: ${ctx.parsed.y.toFixed(3)}` } }
+      tooltip: { callbacks: { label: c => ` ${c.dataset.label}: ${c.parsed.y.toFixed(3)}` } }
     },
     scales: {
       x: {
         grid: { color: 'rgba(153,186,255,0.07)' },
-        ticks: {
-          callback: (_, i) => i % 10 === 0 ? xs[i] + 's' : '',
-          maxRotation: 0
-        },
+        ticks: { callback: (_, i) => (i + 1) % 15 === 0 ? (i + 1) + 's' : '', maxRotation: 0 },
         title: { display: true, text: 'Auth time (seconds)', font: { size: 11 } }
       },
       y: { display: false }
     }
   },
-  plugins: [verticalLinePlugin([
-    { value: 52, color: 'rgba(255,208,114,0.9)', label: '52s' },
-    { value: 75, color: 'rgba(255,140,159,0.9)', label: '75s' },
+  plugins: [vLinePlugin([
+    { value: 48, color: 'rgba(255,208,114,0.9)', label: '48s' },
+    { value: 83, color: 'rgba(255,140,159,0.9)', label: '83s' },
   ])]
 });
 </script>


### PR DESCRIPTION
## 변경 내용

- 차트 데이터를 log-normal 수식으로 동적 생성 (하드코딩 배열 제거)
  - 분포 바: `logNorm(x, μ, σ) × 버킷폭` → 정규화 %
  - 듀얼축 tail rate: CDF 수치 적분으로 결제 수단별 계산
  - 밀도 커브: 두 분포 파라미터 차이 명확화 (벤치마크 σ=0.82 vs 머천트 σ=1.05)
- 관찰값 레이블 중립화: TX-001/002/003 → OBS-A/B/C, 수치도 교체 (52s/75s → 48s/83s)
- 상단에 `⚠ Sample Data` 뱃지 추가
- 데이터 출처/수량도 가데이터로 교체 (524,821 tx · 318 tx)

Closes #10