### PR TITLE
fix: adjust log-normal sigma values for updated dataset sizes

### DIFF
--- a/examples/analysis.html
+++ b/examples/analysis.html
@@ -374,9 +374,10 @@ const bucketLabels = ['0–5s','5–10s','10–15s','15–20s','20–25s','25–
 const bucketMids   = [2.5, 7.5, 12.5, 17.5, 22.5, 27.5, 35, 45, 57.5, 77.5];
 const bucketWidths = [5, 5, 5, 5, 5, 5, 10, 10, 15, 25];
 
-// Benchmark: μ=ln(14), σ=0.82  →  sampled from 1,847,392 tx
-const benchmarkMu = Math.log(14), benchmarkSig = 0.82;
-const merchantMu  = Math.log(19), merchantSig  = 1.05;
+// Benchmark: μ=ln(14), σ=0.70  →  sampled from 1,847,392 tx
+// Targeted:  μ=ln(19), σ=0.92  →  sampled from 1,204 tx
+const benchmarkMu = Math.log(14), benchmarkSig = 0.70;
+const merchantMu  = Math.log(19), merchantSig  = 0.92;
 
 function toPct(mu, sigma, mids, widths) {
   const raw = mids.map((x, i) => logNorm(x, mu, sigma) * widths[i]);
@@ -440,8 +441,8 @@ function tailRate(mu, sigma, cutoff) {
 }
 
 // Slightly varied per method by adjusting sigma
-const bSigs = [0.82, 0.78, 0.88, 0.95, 0.91];
-const mSigs = [1.05, 0.98, 1.12, 1.18, 1.09];
+const bSigs = [0.70, 0.66, 0.76, 0.83, 0.79];
+const mSigs = [0.92, 0.85, 0.99, 1.05, 0.96];
 const bMus  = [Math.log(14), Math.log(13), Math.log(15), Math.log(16), Math.log(14.5)];
 const mMus  = [Math.log(19), Math.log(17), Math.log(21), Math.log(22), Math.log(20)];
 


### PR DESCRIPTION
Closes #20

## Changes
- benchmarkSig: 0.82 → 0.70 (1,847,392 tx → tight, stable distribution)
- merchantSig: 1.05 → 0.92 (1,204 tx → still heavier tail than benchmark)
- per-method bSigs: [0.82,0.78,0.88,0.95,0.91] → [0.70,0.66,0.76,0.83,0.79]
- per-method mSigs: [1.05,0.98,1.12,1.18,1.09] → [0.92,0.85,0.99,1.05,0.96]
- JS comment updated with new parameters