### PR TITLE
fix: update Section 1 chart note — recalculated tail rates and revised narrative

### DIFF
--- a/examples/analysis.html
+++ b/examples/analysis.html
@@ -209,7 +209,7 @@
       </div>
     </div>
     <div class="chart-note">
-      Both distributions are right-skewed with a long tail beyond 40s. The targeted txns tail (60s+) accounts for <strong>6.3%</strong> of transactions vs the benchmark's <strong>3.9%</strong> — a 61% relative elevation that is within expected variance for a 1,204-transaction sample.
+      Both distributions are right-skewed with a long tail beyond 40s. The targeted txns tail (60s+) accounts for <strong>~10.6%</strong> of transactions vs the benchmark's <strong>~1.9%</strong> — a <strong>5.6× elevation</strong> that reflects the targeted group's higher overall median (19s vs 14s), not a system-level regression.
     </div>
   </section>
 


### PR DESCRIPTION
Closes #22

## Changes
- Benchmark tail rate: 3.9% → ~1.9% (σ=0.70 기준 재계산)
- Targeted tail rate: 6.3% → ~10.6% (σ=0.92 기준 재계산)
- Relative elevation: 61% → 5.6×
- 결론 문구: 'within expected variance' → 중앙값 차이에 기인한 tail 설명