### PR TITLE
fix: Section 3 — add OBS-C marker, correct sigma values and tail reasoning

### DIFF
--- a/examples/analysis.html
+++ b/examples/analysis.html
@@ -239,11 +239,12 @@
         <div class="marker-item"><div class="marker-line" style="border-color:var(--accent)"></div> Benchmark distribution</div>
         <div class="marker-item"><div class="marker-line" style="border-color:var(--accent-2)"></div> Targeted Txns distribution</div>
         <div class="marker-item"><div class="marker-line" style="border-color:var(--warning)"></div> 48s (OBS-A)</div>
+        <div class="marker-item"><div class="marker-line" style="border-color:rgba(200,160,255,0.9)"></div> 62s (OBS-C)</div>
         <div class="marker-item"><div class="marker-line" style="border-color:var(--danger)"></div> 83s (OBS-B)</div>
       </div>
     </div>
     <div class="chart-note">
-      OBS-A (48s) and OBS-B (83s) both fall <strong>within the targeted txns distribution tail</strong> — they are not statistical outliers relative to this group's own historical pattern. The targeted txns distribution (μ=ln 19, σ=1.05) has a heavier tail than the benchmark (μ=ln 14, σ=0.82) due to smaller sample size.
+      All three observations fall within the targeted txns distribution tail — OBS-A (48s) at the <strong>~84th percentile</strong>, OBS-C (62s) at the <strong>~89th percentile</strong>, and OBS-B (83s) at the <strong>~95th percentile</strong>. None are statistical outliers relative to this group's own pattern. The targeted txns distribution (μ=ln 19, σ=0.92) has a heavier tail than the benchmark (μ=ln 14, σ=0.70) because this group's auth times are both higher on average and more variable — not a system-level anomaly.
     </div>
   </section>
 
@@ -535,6 +536,7 @@ new Chart(document.getElementById('densityChart'), {
   },
   plugins: [vLinePlugin([
     { value: 48, color: 'rgba(255,208,114,0.9)', label: '48s' },
+    { value: 62, color: 'rgba(200,160,255,0.9)', label: '62s' },
     { value: 83, color: 'rgba(255,140,159,0.9)', label: '83s' },
   ])]
 });


### PR DESCRIPTION
Closes #24

## Changes
- densityChart vLinePlugin에 OBS-C(62s, purple) 마커 추가
- marker legend에 OBS-C 항목 추가
- chart note: σ값 업데이트 (1.05→0.92, 0.82→0.70)
- 'due to smaller sample size' → 올바른 인과 설명으로 교체
- OBS-A(~84th) / OBS-C(~89th) / OBS-B(~95th) 퍼센타일 추가