### PR TITLE
feat: horizontal timeline bar for Section 4 + SKILL.md pattern update

### DIFF
--- a/examples/analysis.html
+++ b/examples/analysis.html
@@ -100,17 +100,66 @@
 
     .two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
 
-    .data-table { width: 100%; border-collapse: collapse; font-size: 13px; }
-    .data-table th {
-      text-align: left; padding: 10px 14px;
-      font-size: 11px; font-weight: 700; letter-spacing: 0.07em; text-transform: uppercase;
-      color: var(--text-muted); border-bottom: 1px solid var(--border);
+    /* Horizontal timeline bar — Section 4 */
+    .tbar-rows { display: flex; flex-direction: column; }
+    .tbar-row {
+      display: grid; grid-template-columns: 100px 1fr 56px;
+      gap: 12px; align-items: center;
+      padding: 14px 0; border-bottom: 1px solid rgba(153,186,255,0.07);
     }
-    .data-table td { padding: 10px 14px; border-bottom: 1px solid rgba(153,186,255,0.07); color: var(--text-muted); }
-    .data-table tr:last-child td { border-bottom: none; }
-    .data-table td.num { font-weight: 600; color: var(--text); text-align: right; font-variant-numeric: tabular-nums; }
-    .data-table td.hi  { color: var(--warning); font-weight: 700; text-align: right; }
-    .data-table td.ok  { color: var(--accent-2); font-weight: 600; }
+    .tbar-row:last-child { border-bottom: none; }
+    .tbar-label strong { display: block; font-size: 13px; font-weight: 700; }
+    .tbar-label span   { display: block; font-size: 11px; color: var(--text-muted); margin-top: 2px; }
+    .tbar-col { display: flex; flex-direction: column; gap: 6px; }
+    .tbar-track {
+      position: relative; height: 32px;
+      background: rgba(153,186,255,0.06); border-radius: 6px; overflow: visible;
+    }
+    .tbar-fill {
+      position: absolute; left: 0; top: 0; height: 100%;
+      display: flex; border-radius: 6px; overflow: hidden;
+    }
+    .tbar-seg-user   { background: rgba(104,182,255,0.55); }
+    .tbar-seg-system { background: rgba(112,225,203,0.55); }
+    .tbar-sublabel {
+      position: relative; height: 18px;
+    }
+    .tbar-sub {
+      position: absolute; font-size: 11px; font-weight: 500;
+      transform: translateX(-50%); white-space: nowrap;
+    }
+    .tbar-sub.user { color: rgba(104,182,255,0.85); }
+    .tbar-sub.sys  { color: var(--accent-2); }
+    .tbar-vmark {
+      position: absolute; top: -8px; bottom: -8px;
+      border-left: 2px dashed rgba(255,208,114,0.7); pointer-events: none;
+    }
+    .tbar-vmark-label {
+      position: absolute; top: -20px; left: 4px;
+      font-size: 10px; color: var(--warning); font-weight: 600; white-space: nowrap;
+    }
+    .tbar-dot {
+      position: absolute; top: 50%; transform: translate(-50%, -50%);
+      width: 10px; height: 10px; border-radius: 50%;
+      background: var(--accent-2); border: 2px solid rgba(112,225,203,0.4);
+      box-shadow: 0 0 6px rgba(112,225,203,0.5);
+    }
+    .tbar-total { font-size: 13px; font-weight: 700; text-align: right; white-space: nowrap; }
+    .tbar-xaxis {
+      display: grid; grid-template-columns: 100px 1fr 56px; gap: 12px; margin-top: 4px;
+    }
+    .tbar-ticks { position: relative; height: 20px; }
+    .tbar-tick {
+      position: absolute; transform: translateX(-50%);
+      font-size: 10px; color: rgba(153,186,255,0.4);
+    }
+    .tbar-legend {
+      display: flex; flex-wrap: wrap; gap: 16px; margin-bottom: 16px; font-size: 12px; color: var(--text-muted);
+    }
+    .tbar-legend-item { display: flex; align-items: center; gap: 6px; }
+    .tbar-legend-swatch { width: 14px; height: 14px; border-radius: 3px; }
+    .tbar-legend-line { width: 20px; border-top: 2px dashed rgba(255,208,114,0.7); }
+    .tbar-legend-dot { width: 10px; height: 10px; border-radius: 50%; background: var(--accent-2); }
 
     .marker-legend { display: flex; flex-wrap: wrap; gap: 16px; margin-top: 12px; }
     .marker-item { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--text-muted); }
@@ -248,58 +297,26 @@
     </div>
   </section>
 
-  <!-- Section 4: Raw data table -->
+  <!-- Section 4: Horizontal timeline bar -->
   <section class="section">
     <div class="section-head">
       <h2>Section 4 — Observation Detail</h2>
-      <p>Breakdown of the three flagged transactions with API stage timing and classification.</p>
+      <p>Auth time breakdown by stage — user interaction vs system processing per observation.</p>
     </div>
-    <div class="chart-wrap" style="padding:0;overflow:hidden">
-      <table class="data-table">
-        <thead>
-          <tr>
-            <th>Observation</th>
-            <th>Method</th>
-            <th>API stages (ms)</th>
-            <th>Auth stage</th>
-            <th>Total</th>
-            <th>vs benchmark p50 (14s)</th>
-            <th>Classification</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>OBS-A</td>
-            <td>Card</td>
-            <td class="num">&lt; 500 ms</td>
-            <td class="hi">48s</td>
-            <td class="num">~49s</td>
-            <td class="hi">~2.4×</td>
-            <td><span class="tag warn">Within targeted tail</span></td>
-          </tr>
-          <tr>
-            <td>OBS-B</td>
-            <td>Card</td>
-            <td class="num">&lt; 500 ms</td>
-            <td class="hi">83s</td>
-            <td class="num">~84s</td>
-            <td class="hi">~5.9×</td>
-            <td><span class="tag warn">Within targeted tail</span></td>
-          </tr>
-          <tr>
-            <td>OBS-C</td>
-            <td>Wallet</td>
-            <td class="num">&lt; 500 ms</td>
-            <td class="num">62s</td>
-            <td class="num">~62s</td>
-            <td class="hi">~4.4×</td>
-            <td><span class="tag ok">Within targeted tail</span></td>
-          </tr>
-        </tbody>
-      </table>
+    <div class="tbar-legend">
+      <div class="tbar-legend-item"><div class="tbar-legend-swatch" style="background:rgba(104,182,255,0.55)"></div> User interaction (auth stage)</div>
+      <div class="tbar-legend-item"><div class="tbar-legend-swatch" style="background:rgba(112,225,203,0.55)"></div> System processing</div>
+      <div class="tbar-legend-item"><div class="tbar-legend-line"></div> Benchmark p50 (14s)</div>
+      <div class="tbar-legend-item"><div class="tbar-legend-dot"></div> API call completion</div>
+    </div>
+    <div class="tbar-rows" id="tbarRows"></div>
+    <div class="tbar-xaxis">
+      <div></div>
+      <div class="tbar-ticks" id="tbarTicks"></div>
+      <div></div>
     </div>
     <div class="chart-note" style="margin-top:14px">
-      API stages complete in <strong>under 500ms</strong> for all three observations. The auth stage reflects user interaction time, which is outside server control.
+      The auth stage (user interaction) accounts for the majority of total time across all observations. System processing completes in <strong>under 500ms</strong> and is outside server control for the auth stage.
     </div>
   </section>
 
@@ -539,6 +556,62 @@ new Chart(document.getElementById('densityChart'), {
     { value: 62, color: 'rgba(200,160,255,0.9)', label: '62s' },
     { value: 83, color: 'rgba(255,140,159,0.9)', label: '83s' },
   ])]
+});
+
+// ── Section 4: Horizontal timeline bar ────────────────────────────────────
+const TBAR_MAX = 115;
+const TBAR_P50 = 14;
+const tbarObs = [
+  { id: 'OBS-A', method: 'Card',   auth: 48, api: 8   },
+  { id: 'OBS-B', method: 'Card',   auth: 83, api: 0.4 },
+  { id: 'OBS-C', method: 'Wallet', auth: 62, api: 0.4 },
+];
+
+const tbarRowsEl = document.getElementById('tbarRows');
+tbarObs.forEach((o, idx) => {
+  const total   = o.auth + o.api;
+  const fillPct = (total / TBAR_MAX * 100).toFixed(2);
+  const userPct = (o.auth / total * 100).toFixed(1);
+  const sysPct  = (o.api  / total * 100).toFixed(1);
+  const benchPct = (TBAR_P50 / TBAR_MAX * 100).toFixed(2);
+  const dotPct  = (o.auth / TBAR_MAX * 100).toFixed(2);
+  const userMid = (o.auth / 2 / TBAR_MAX * 100).toFixed(1);
+  const sysMid  = ((o.auth + o.api / 2) / TBAR_MAX * 100).toFixed(1);
+  const sysLabel = o.api >= 1 ? `${o.api}s sys · ${(o.api/total*100).toFixed(0)}%` : `< 1s sys · < 1%`;
+
+  const row = document.createElement('div');
+  row.className = 'tbar-row';
+  row.innerHTML = `
+    <div class="tbar-label">
+      <strong>${o.id}</strong>
+      <span>${o.method}</span>
+    </div>
+    <div class="tbar-col">
+      <div class="tbar-track">
+        <div class="tbar-fill" style="width:${fillPct}%">
+          <div class="tbar-seg-user"   style="width:${userPct}%"></div>
+          <div class="tbar-seg-system" style="width:${sysPct}%;min-width:${o.api<1?'8px':'0'}"></div>
+        </div>
+        ${idx === 0 ? `<div class="tbar-vmark" style="left:${benchPct}%"><span class="tbar-vmark-label">p50 14s</span></div>` : `<div class="tbar-vmark" style="left:${benchPct}%"></div>`}
+        <div class="tbar-dot" style="left:${dotPct}%"></div>
+      </div>
+      <div class="tbar-sublabel">
+        <span class="tbar-sub user" style="left:${userMid}%">${o.auth}s · ${(o.auth/total*100).toFixed(0)}% user</span>
+        <span class="tbar-sub sys"  style="left:${sysMid}%">${sysLabel}</span>
+      </div>
+    </div>
+    <div class="tbar-total">~${Math.round(total)}s</div>
+  `;
+  tbarRowsEl.appendChild(row);
+});
+
+const tbarTicksEl = document.getElementById('tbarTicks');
+[0, 20, 40, 60, 80, 100, TBAR_MAX].forEach(v => {
+  const t = document.createElement('div');
+  t.className = 'tbar-tick';
+  t.style.left = (v / TBAR_MAX * 100) + '%';
+  t.textContent = v + 's';
+  tbarTicksEl.appendChild(t);
 });
 </script>
 </body>

--- a/skills/visualize/SKILL.md
+++ b/skills/visualize/SKILL.md
@@ -85,8 +85,15 @@ Use `analysis` when the core deliverable is data-driven charts with statistical 
 - Density curve — log-normal or KDE fit with observed-value vertical markers
 - Stacked bar — composition across categories
 - Data table — raw values alongside charts when precision matters
+- Horizontal timeline bar — stage breakdown per observation (e.g., user interaction vs system processing); label each segment centered below its midpoint; for segments too narrow to label inside, omit inner text and show the value below only; use a vertical dashed marker for reference baselines (e.g., p50)
 
 **Marker convention**: observed values (specific transactions, incidents) are shown as vertical dashed lines with labeled callouts — never buried in prose.
+
+**Horizontal timeline bar — label rules**:
+- Each segment gets one centered sub-label below the bar: `{time}s · {pct}% {name}`
+- Sub-label `left` = `(segmentStart + segmentWidth / 2) / MAX_S * 100%`, `transform: translateX(-50%)`
+- Segments under ~5% of total width: omit inner text; sub-label below still shown
+- Right column shows total time only (`~Xs`)
 
 **Interpretation placement**: one short paragraph directly below each chart. Do not save all interpretation for the end.
 


### PR DESCRIPTION
Closes #30
Closes #31

## Changes

### analysis.html
- Section 4 테이블 → 수평 스택 바 차트로 교체
- 각 세그먼트 중앙 아래 레이블 배치 (user/sys)
- benchmark p50 수직 마커 + API call dot
- CSS: tbar-* 클래스 추가, 기존 data-table/tag CSS 제거

### SKILL.md
- Chart patterns에 'Horizontal timeline bar' 패턴 추가
- 세그먼트 중앙 하단 레이블 계산 공식 명시
- 좁은 세그먼트(< 5%) 처리 규칙 추가