### PR TITLE
fix: analysis.html review — content errors, design system compliance, cleanup

### DIFF
--- a/examples/analysis.html
+++ b/examples/analysis.html
@@ -11,7 +11,9 @@
   <style>
     :root {
       color-scheme: dark;
+      --bg: #08111f;
       --surface: rgba(12, 21, 36, 0.92);
+      --surface-strong: rgba(16, 28, 46, 0.98);
       --border: rgba(153, 186, 255, 0.14);
       --border-strong: rgba(153, 186, 255, 0.28);
       --text: #edf3ff;
@@ -25,10 +27,11 @@
       --radius-md: 14px;
       --shadow: 0 24px 72px rgba(0,0,0,0.34);
       --font-sans: "Inter","Noto Sans KR",-apple-system,sans-serif;
-      --max: 1100px;
+      --font-mono: "SFMono-Regular","JetBrains Mono","Consolas",monospace;
+      --max: 1240px;
     }
     * { box-sizing: border-box; }
-    html, body { margin: 0; min-height: 100%; }
+    html, body { margin: 0; min-height: 100%; background: var(--bg); }
     body {
       font-family: var(--font-sans);
       color: var(--text);
@@ -46,6 +49,7 @@
       border: 1px solid var(--border);
       background: linear-gradient(180deg, rgba(15,27,44,0.98), rgba(8,15,28,0.94));
       border-radius: var(--radius-xl); padding: 32px; box-shadow: var(--shadow);
+      margin-bottom: 4px;
     }
     .eyebrow {
       display: inline-flex; align-items: center; gap: 8px;
@@ -60,7 +64,7 @@
       color: var(--warning); font-size: 11px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase;
       vertical-align: middle;
     }
-    h1 { margin: 0 0 14px; font-size: clamp(2rem, 4vw, 3.2rem); line-height: 1.08; letter-spacing: -0.035em; font-weight: 900; }
+    h1 { margin: 0 0 14px; font-size: clamp(2.25rem, 5vw, 3.75rem); line-height: 1.08; letter-spacing: -0.035em; font-weight: 800; }
     .hero-meta { display: flex; flex-wrap: wrap; gap: 20px; margin-top: 20px; }
     .meta-item { font-size: 13px; color: var(--text-muted); }
     .meta-item strong { color: var(--text); font-weight: 600; }
@@ -70,9 +74,8 @@
       border-radius: var(--radius-xl); padding: 26px; box-shadow: var(--shadow);
     }
     .section-head { margin-bottom: 20px; }
-    h2 { margin: 0 0 6px; font-size: clamp(1.3rem, 2.5vw, 1.8rem); line-height: 1.1; letter-spacing: -0.03em; }
-    .section-head p { margin: 0; color: var(--text-muted); font-size: 14px; }
-    h3 { margin: 0 0 8px; font-size: 1.05rem; letter-spacing: -0.02em; font-weight: 700; }
+    h2 { margin: 0 0 6px; font-size: clamp(1.6rem, 3vw, 2.3rem); line-height: 1.1; letter-spacing: -0.03em; }
+    .section-head p { margin: 0; color: var(--text-muted); font-size: 15px; }
     p { margin: 0; color: var(--text-muted); font-size: 15px; }
 
     .obs-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; }
@@ -94,11 +97,9 @@
       margin-top: 14px; padding: 12px 16px;
       border-radius: 10px; background: rgba(255,255,255,0.03);
       border-left: 3px solid var(--border-strong);
-      font-size: 13px; color: var(--text-muted); line-height: 1.65;
+      font-size: 14px; color: var(--text-muted); line-height: 1.65;
     }
     .chart-note strong { color: var(--text); }
-
-    .two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
 
     /* Horizontal timeline bar — Section 4 */
     .tbar-rows { display: flex; flex-direction: column; }
@@ -199,19 +200,18 @@
     }
     .synth-label { font-size: 11px; font-weight: 800; letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 10px; }
     .synth-verdict { font-size: 15px; font-weight: 700; color: var(--text); margin-bottom: 8px; letter-spacing: -0.02em; }
-    .synth-desc { font-size: 13px; color: var(--text-muted); line-height: 1.65; }
-
-    .tag {
-      display: inline-flex; align-items: center; padding: 3px 10px;
-      border-radius: 999px; font-size: 11px; font-weight: 700;
-    }
-    .tag.ok   { background: rgba(112,225,203,0.1); color: var(--accent-2); border: 1px solid rgba(112,225,203,0.25); }
-    .tag.warn { background: rgba(255,208,114,0.1); color: var(--warning);  border: 1px solid rgba(255,208,114,0.25); }
+    .synth-desc { font-size: 14px; color: var(--text-muted); line-height: 1.65; }
 
     @media (max-width: 900px) {
-      .obs-grid  { grid-template-columns: repeat(2, 1fr); }
-      .two-col   { grid-template-columns: 1fr; }
-      .synth-grid{ grid-template-columns: 1fr; }
+      .obs-grid   { grid-template-columns: repeat(2, 1fr); }
+      .synth-grid { grid-template-columns: 1fr; }
+    }
+    @media (max-width: 375px) {
+      body { overflow-x: hidden; }
+      .page { width: calc(100% - 20px); }
+      .hero, .section { padding: 18px; }
+      .obs-grid { grid-template-columns: 1fr; }
+      p { font-size: 14px; }
     }
     @media print {
       body { background: #fff; color: #111; }
@@ -281,6 +281,7 @@
         <div class="marker-item"><div class="marker-line" style="border-color:var(--accent)"></div> Benchmark</div>
         <div class="marker-item"><div class="marker-line" style="border-color:var(--accent-2)"></div> Targeted Txns</div>
         <div class="marker-item"><div class="marker-line" style="border-color:var(--warning)"></div> 48s (OBS-A)</div>
+        <div class="marker-item"><div class="marker-line" style="border-color:rgba(200,160,255,0.9)"></div> 62s (OBS-C)</div>
         <div class="marker-item"><div class="marker-line" style="border-color:var(--danger)"></div> 83s (OBS-B)</div>
       </div>
     </div>
@@ -343,7 +344,7 @@
       <div></div>
     </div>
     <div class="chart-note" style="margin-top:14px">
-      The auth stage (user interaction) accounts for the majority of total time across all observations. System processing completes in <strong>under 500ms</strong> and is outside server control for the auth stage.
+      The auth stage (user interaction) accounts for the majority of total time across all observations. OBS-B and OBS-C show system processing <strong>under 500ms</strong>; OBS-A's API stage is ~8s (~14% of total). All auth-stage time is user interaction and outside server control.
     </div>
   </section>
 
@@ -357,9 +358,9 @@
     </div>
     <div class="synth-grid">
       <div class="synth-card">
-        <div class="synth-label" style="color:var(--accent)">Section 4 · Stage Breakdown</div>
-        <div class="synth-verdict">Not a server-side issue</div>
-        <div class="synth-desc">System processing (API stages) accounts for less than 500ms across all three observations — under 15% of total time. The auth stage is user interaction, which is outside server control.</div>
+        <div class="synth-label" style="color:var(--warning)">Section 2 · Tail Rate by Method</div>
+        <div class="synth-verdict">Pattern is cross-method, not isolated</div>
+        <div class="synth-desc">60s+ elevation appears across card, wallet, and bank transfer. A method-specific regression would show one method spiking. The uniform cross-method pattern points to a shared client-side environmental factor.</div>
       </div>
       <div class="synth-card">
         <div class="synth-label" style="color:var(--accent-2)">Section 3 · Density Fit</div>
@@ -367,9 +368,9 @@
         <div class="synth-desc">OBS-A (48s), OBS-C (62s), and OBS-B (83s) fall at the 84th, 89th, and 95th percentile of the targeted txns distribution. They are tail values — not anomalies outside the fitted model.</div>
       </div>
       <div class="synth-card">
-        <div class="synth-label" style="color:var(--warning)">Section 2 · Tail Rate by Method</div>
-        <div class="synth-verdict">Pattern is cross-method, not isolated</div>
-        <div class="synth-desc">60s+ elevation appears across card, wallet, and bank transfer. A method-specific regression would show one method spiking. The uniform cross-method pattern points to a shared client-side environmental factor.</div>
+        <div class="synth-label" style="color:var(--accent)">Section 4 · Stage Breakdown</div>
+        <div class="synth-verdict">Not a server-side issue</div>
+        <div class="synth-desc">OBS-B and OBS-C show system processing under 500ms. OBS-A's API stage is ~8s (~14% of total). All auth-stage time is user interaction, which is outside server control.</div>
       </div>
     </div>
   </section>
@@ -424,7 +425,7 @@ const bucketWidths = [5, 5, 5, 5, 5, 5, 10, 10, 15, 25];
 // Benchmark: μ=ln(14), σ=0.70  →  sampled from 1,847,392 tx
 // Targeted:  μ=ln(19), σ=0.92  →  sampled from 1,204 tx
 const benchmarkMu = Math.log(14), benchmarkSig = 0.70;
-const merchantMu  = Math.log(19), merchantSig  = 0.92;
+const targetedMu  = Math.log(19), targetedSig  = 0.92;
 
 function toPct(mu, sigma, mids, widths) {
   const raw = mids.map((x, i) => logNorm(x, mu, sigma) * widths[i]);
@@ -433,7 +434,7 @@ function toPct(mu, sigma, mids, widths) {
 }
 
 const benchmarkDist = toPct(benchmarkMu, benchmarkSig, bucketMids, bucketWidths);
-const merchantDist  = toPct(merchantMu,  merchantSig,  bucketMids, bucketWidths);
+const targetedDist  = toPct(targetedMu,  targetedSig,  bucketMids, bucketWidths);
 
 // ── Chart 1: Distribution bar ──────────────────────────────────────────────
 new Chart(document.getElementById('distChart'), {
@@ -450,7 +451,7 @@ new Chart(document.getElementById('distChart'), {
       },
       {
         label: 'Targeted Txns (%)',
-        data: merchantDist,
+        data: targetedDist,
         backgroundColor: 'rgba(112,225,203,0.18)',
         borderColor: 'rgba(112,225,203,0.55)',
         borderWidth: 1.5, borderRadius: 4,
@@ -469,9 +470,9 @@ new Chart(document.getElementById('distChart'), {
     }
   },
   plugins: [vLinePlugin([
-    // bucket index ≈ continuous axis value index
-    { value: 7.6,  color: 'rgba(255,208,114,0.9)', label: '48s' },
-    { value: 9.15, color: 'rgba(255,140,159,0.9)', label: '83s' },
+    { value: 7.6,  color: 'rgba(255,208,114,0.9)',  label: '48s' },
+    { value: 8.7,  color: 'rgba(200,160,255,0.9)',  label: '62s' },
+    { value: 9.15, color: 'rgba(255,140,159,0.9)',  label: '83s' },
   ])]
 });
 
@@ -489,12 +490,12 @@ function tailRate(mu, sigma, cutoff) {
 
 // Slightly varied per method by adjusting sigma
 const bSigs = [0.70, 0.66, 0.76, 0.83, 0.79];
-const mSigs = [0.92, 0.85, 0.99, 1.05, 0.96];
+const tSigs = [0.92, 0.85, 0.99, 1.05, 0.96];
 const bMus  = [Math.log(14), Math.log(13), Math.log(15), Math.log(16), Math.log(14.5)];
-const mMus  = [Math.log(19), Math.log(17), Math.log(21), Math.log(22), Math.log(20)];
+const tMus  = [Math.log(19), Math.log(17), Math.log(21), Math.log(22), Math.log(20)];
 
-const benchTail = bMus.map((mu, i) => tailRate(mu, bSigs[i], 60));
-const mercTail  = mMus.map((mu, i) => tailRate(mu, mSigs[i], 60));
+const benchTail   = bMus.map((mu, i) => tailRate(mu, bSigs[i], 60));
+const targetedTail = tMus.map((mu, i) => tailRate(mu, tSigs[i], 60));
 
 new Chart(document.getElementById('tailChart'), {
   type: 'bar',
@@ -512,7 +513,7 @@ new Chart(document.getElementById('tailChart'), {
       {
         type: 'line',
         label: 'Targeted Txns 60s+ (%)',
-        data: mercTail,
+        data: targetedTail,
         borderColor: 'rgba(112,225,203,0.85)',
         backgroundColor: 'rgba(112,225,203,0.08)',
         borderWidth: 2.5,
@@ -539,7 +540,7 @@ new Chart(document.getElementById('tailChart'), {
 // ── Chart 3: Density curves ────────────────────────────────────────────────
 const xs = Array.from({ length: 120 }, (_, i) => i + 1);
 const bDens = xs.map(x => logNorm(x, benchmarkMu, benchmarkSig));
-const mDens = xs.map(x => logNorm(x, merchantMu,  merchantSig));
+const mDens = xs.map(x => logNorm(x, targetedMu,  targetedSig));
 const peak  = Math.max(...bDens, ...mDens);
 const bNorm = bDens.map(v => v / peak);
 const mNorm = mDens.map(v => v / peak);
@@ -678,8 +679,8 @@ document.querySelectorAll('.tbar-row').forEach((row, idx) => {
     const ttW = tbarTT.offsetWidth, ttH = tbarTT.offsetHeight;
     const x = e.clientX + 16;
     const y = e.clientY - 10;
-    tbarTT.style.left = (x + ttW > window.innerWidth  - 8 ? e.clientX - ttW - 16 : x) + 'px';
-    tbarTT.style.top  = (y + ttH > window.innerHeight - 8 ? e.clientY - ttH - 10 : y) + 'px';
+    tbarTT.style.left = Math.max(8, x + ttW > window.innerWidth  - 8 ? e.clientX - ttW - 16 : x) + 'px';
+    tbarTT.style.top  = Math.max(8, y + ttH > window.innerHeight - 8 ? e.clientY - ttH - 10 : y) + 'px';
   });
 
   row.addEventListener('mouseleave', () => tbarTT.classList.remove('visible'));


### PR DESCRIPTION
Closes #39

## Must-Fix
- **Section 4 chart-note + Synthesis S4**: 'under 500ms' was wrong for OBS-A (api=8s). Now: 'OBS-B and OBS-C show system processing under 500ms; OBS-A's API stage is ~8s (~14% of total)'
- **Section 1**: Added OBS-C (62s) vertical marker at index 8.7 + legend entry (purple)

## Should-Fix
- h1: `clamp(2.25rem,5vw,3.75rem)` + font-weight 800 (Inter max load is 800)
- h2: `clamp(1.6rem,3vw,2.3rem)`
- .section-head p: 14px → 15px; .chart-note: 13px → 14px; .synth-desc: 13px → 14px
- Added `--bg`, `--surface-strong`, `--font-mono` CSS variables; html/body background fallback
- `--max`: 1100px → 1240px
- Added `@media (max-width: 375px)` breakpoint (obs-grid → 1col, padding, overflow-x)
- Hero `margin-bottom: 4px`
- Synthesis card order: S4→S3→S2 → **S2→S3→S4** (document flow)

## Nice-to-Have
- Removed dead CSS: .two-col, h3, .tag
- Renamed JS variables: merchantDist/merchantMu/merchantSig/mercTail/mMus/mSigs → targeted*
- Tooltip left-edge guard: `Math.max(8, ...)`