### PR TITLE
chore: bump version to 1.0.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "claude-visualize",
       "source": "./",
       "description": "Generate self-contained HTML visualizations from documents and data",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "author": {
         "name": "SeokRae"
       }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-visualize",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Generate self-contained HTML visualizations from documents and data",
   "author": {
     "name": "SeokRae",


### PR DESCRIPTION
Closes #47

## 변경사항
- `.claude-plugin/plugin.json`: `1.0.1` → `1.0.2`
- `.claude-plugin/marketplace.json`: `1.0.1` → `1.0.2`

## 배경
이미 머지된 버그 수정 PR(#41, #43)에 version bump가 누락되어 `autoUpdate`가 캐시를 갱신하지 못하는 상태였음.